### PR TITLE
Point at renamed shelly-go module

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,5 +127,5 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 ## Acknowledgments
 
 - Built with the [Terraform Plugin Framework](https://github.com/hashicorp/terraform-plugin-framework)
-- Uses structs from [go-shelly-lite](https://github.com/DonRobo/go-shelly-lite) for Shelly device communication
+- Uses structs from [shelly-go](https://github.com/DonRobo/shelly-go) for Shelly device communication
 

--- a/generate.go
+++ b/generate.go
@@ -1,6 +1,6 @@
 package main
 
-// Generate the per-component config resources from the go-shelly-lite IR
+// Generate the per-component config resources from the shelly-go IR
 // (which is itself generated from the Shelly API docs). Run before tfplugindocs
 // so the generated resources are included in the documentation.
 //

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.4
 
 require (
-	github.com/DonRobo/go-shelly-lite v0.0.0-20260621085622-aff896203dce
+	github.com/DonRobo/shelly-go v0.0.0-20260621181148-fbb778565ac7
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/DonRobo/go-shelly-lite v0.0.0-20260621085622-aff896203dce h1:ogwLUHhWzoQFdwOCQsQFIp87nfwNy/v2XSbJ8DHbMpU=
-github.com/DonRobo/go-shelly-lite v0.0.0-20260621085622-aff896203dce/go.mod h1:a+yLSRdwRNf3EzVqtFgOkykceudttFAwEQib9TPV8dM=
+github.com/DonRobo/shelly-go v0.0.0-20260621181148-fbb778565ac7 h1:EamD6mZVT4etcL6i7YnRadl6qwuTWwuZNRtoxuUujOw=
+github.com/DonRobo/shelly-go v0.0.0-20260621181148-fbb778565ac7/go.mod h1:RN1sX+/X8foe8AVeOEt0TWujIoREl0vhsHnOQSQqCp8=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/internal/provider/cct_config_resource_gen.go
+++ b/internal/provider/cct_config_resource_gen.go
@@ -5,7 +5,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"

--- a/internal/provider/cloud_config_resource_gen.go
+++ b/internal/provider/cloud_config_resource_gen.go
@@ -4,7 +4,7 @@ package provider
 
 import (
 	"context"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/cover_config_resource_gen.go
+++ b/internal/provider/cover_config_resource_gen.go
@@ -5,7 +5,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/dali_config_resource_gen.go
+++ b/internal/provider/dali_config_resource_gen.go
@@ -4,7 +4,7 @@ package provider
 
 import (
 	"context"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/em1_config_resource_gen.go
+++ b/internal/provider/em1_config_resource_gen.go
@@ -5,7 +5,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/em1data_config_resource_gen.go
+++ b/internal/provider/em1data_config_resource_gen.go
@@ -5,7 +5,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/em_config_resource_gen.go
+++ b/internal/provider/em_config_resource_gen.go
@@ -5,7 +5,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"

--- a/internal/provider/emdata_config_resource_gen.go
+++ b/internal/provider/emdata_config_resource_gen.go
@@ -5,7 +5,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/eth_config_resource_gen.go
+++ b/internal/provider/eth_config_resource_gen.go
@@ -4,7 +4,7 @@ package provider
 
 import (
 	"context"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"

--- a/internal/provider/flood_config_resource_gen.go
+++ b/internal/provider/flood_config_resource_gen.go
@@ -5,7 +5,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/gen/main.go
+++ b/internal/provider/gen/main.go
@@ -1,4 +1,4 @@
-// Command gen emits Terraform resources from the go-shelly-lite IR.
+// Command gen emits Terraform resources from the shelly-go IR.
 //
 // For every Shelly component that has a generated library config (so its Go
 // field names match the IR) and a SetConfig method, it writes a
@@ -19,7 +19,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/DonRobo/go-shelly-lite/gen"
+	"github.com/DonRobo/shelly-go/gen"
 )
 
 const outDir = "internal/provider"
@@ -126,7 +126,7 @@ func emitResource(c *gen.Component, fields []scalarField) ([]byte, error) {
 
 	imp := newImports(
 		"context",
-		"github.com/DonRobo/go-shelly-lite",
+		"github.com/DonRobo/shelly-go",
 		"github.com/hashicorp/terraform-plugin-framework/diag",
 		"github.com/hashicorp/terraform-plugin-framework/path",
 		"github.com/hashicorp/terraform-plugin-framework/resource",
@@ -338,9 +338,9 @@ func removeGenerated(dir string) error {
 }
 
 func libraryDir() (string, error) {
-	out, err := exec.Command("go", "list", "-m", "-f", "{{.Dir}}", "github.com/DonRobo/go-shelly-lite").Output()
+	out, err := exec.Command("go", "list", "-m", "-f", "{{.Dir}}", "github.com/DonRobo/shelly-go").Output()
 	if err != nil {
-		return "", fmt.Errorf("locate go-shelly-lite: %w", err)
+		return "", fmt.Errorf("locate shelly-go: %w", err)
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/internal/provider/humidity_config_resource_gen.go
+++ b/internal/provider/humidity_config_resource_gen.go
@@ -5,7 +5,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/illuminance_config_resource_gen.go
+++ b/internal/provider/illuminance_config_resource_gen.go
@@ -5,7 +5,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/input_config_resource.go
+++ b/internal/provider/input_config_resource.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"

--- a/internal/provider/light_config_resource_gen.go
+++ b/internal/provider/light_config_resource_gen.go
@@ -5,7 +5,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"

--- a/internal/provider/matter_config_resource_gen.go
+++ b/internal/provider/matter_config_resource_gen.go
@@ -4,7 +4,7 @@ package provider
 
 import (
 	"context"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/modbus_config_resource_gen.go
+++ b/internal/provider/modbus_config_resource_gen.go
@@ -4,7 +4,7 @@ package provider
 
 import (
 	"context"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/mqtt_config_resource_gen.go
+++ b/internal/provider/mqtt_config_resource_gen.go
@@ -4,7 +4,7 @@ package provider
 
 import (
 	"context"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/pill_config_resource_gen.go
+++ b/internal/provider/pill_config_resource_gen.go
@@ -4,7 +4,7 @@ package provider
 
 import (
 	"context"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/pm1_config_resource_gen.go
+++ b/internal/provider/pm1_config_resource_gen.go
@@ -5,7 +5,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/presence_config_resource_gen.go
+++ b/internal/provider/presence_config_resource_gen.go
@@ -4,7 +4,7 @@ package provider
 
 import (
 	"context"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/presencezone_config_resource_gen.go
+++ b/internal/provider/presencezone_config_resource_gen.go
@@ -5,7 +5,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/rgb_config_resource_gen.go
+++ b/internal/provider/rgb_config_resource_gen.go
@@ -5,7 +5,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"

--- a/internal/provider/rgbcct_config_resource_gen.go
+++ b/internal/provider/rgbcct_config_resource_gen.go
@@ -5,7 +5,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"

--- a/internal/provider/rgbw_config_resource_gen.go
+++ b/internal/provider/rgbw_config_resource_gen.go
@@ -5,7 +5,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"

--- a/internal/provider/script_config_resource_gen.go
+++ b/internal/provider/script_config_resource_gen.go
@@ -5,7 +5,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/serial_config_resource_gen.go
+++ b/internal/provider/serial_config_resource_gen.go
@@ -5,7 +5,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/shelly_device_data_source.go
+++ b/internal/provider/shelly_device_data_source.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"

--- a/internal/provider/smoke_config_resource_gen.go
+++ b/internal/provider/smoke_config_resource_gen.go
@@ -5,7 +5,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/switch_config_resource.go
+++ b/internal/provider/switch_config_resource.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"

--- a/internal/provider/sys_config_resource.go
+++ b/internal/provider/sys_config_resource.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 
-	shelly "github.com/DonRobo/go-shelly-lite"
+	shelly "github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/temperature_config_resource_gen.go
+++ b/internal/provider/temperature_config_resource_gen.go
@@ -5,7 +5,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/ui_config_resource_gen.go
+++ b/internal/provider/ui_config_resource_gen.go
@@ -4,7 +4,7 @@ package provider
 
 import (
 	"context"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/voltmeter_config_resource_gen.go
+++ b/internal/provider/voltmeter_config_resource_gen.go
@@ -5,7 +5,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/ws_config_resource_gen.go
+++ b/internal/provider/ws_config_resource_gen.go
@@ -4,7 +4,7 @@ package provider
 
 import (
 	"context"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/zigbee_config_resource_gen.go
+++ b/internal/provider/zigbee_config_resource_gen.go
@@ -4,7 +4,7 @@ package provider
 
 import (
 	"context"
-	"github.com/DonRobo/go-shelly-lite"
+	"github.com/DonRobo/shelly-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"


### PR DESCRIPTION
## What

Follow-up to [DonRobo/shelly-go#3](https://github.com/DonRobo/shelly-go/pull/3), which renamed the backing library's module path `github.com/DonRobo/go-shelly-lite` → `github.com/DonRobo/shelly-go` (Go **package name unchanged**). This re-pins the provider and updates every reference.

## Changes

- **`go.mod`**: `require github.com/DonRobo/shelly-go` at the merged `main` commit (`fbb7785`).
- **Generator** (`internal/provider/gen/main.go`): its own `…/gen` import, the import string it *emits* into each resource, and the `go list -m` module lookup.
- **Hand-written** resources/data source (4 files), plus `generate.go` and README references.
- **Regenerated** the 31 config resources, so their imports use the new path (not hand-edited).

Because the package is still `shelly`, no `shelly.X` call site changed — this is purely an import-path move.

## Verification

- `go build ./... && go vet ./... && go test ./...` pass.
- `go generate ./...` is **idempotent** — committed generated code matches a fresh run (verified via stage-then-regenerate, no resulting diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)