### PR TITLE
provider: codegen for config arrays and read-only fields

### DIFF
--- a/docs/resources/dali_config.md
+++ b/docs/resources/dali_config.md
@@ -22,6 +22,7 @@ description: |-
 ### Optional
 
 - `cg_count` (Number) Number of scanned control gears (null if scan has never been executed)
+- `errors` (List of String) Shown only if at least one error is present. May contain control_gear_missing, driver
 - `scan` (Attributes) (see [below for nested schema](#nestedatt--scan))
 
 <a id="nestedatt--scan"></a>

--- a/docs/resources/devicepower_config.md
+++ b/docs/resources/devicepower_config.md
@@ -23,6 +23,7 @@ description: |-
 ### Optional
 
 - `battery` (Attributes) (see [below for nested schema](#nestedatt--battery))
+- `errors` (List of String) Whether external power source is connected
 
 <a id="nestedatt--battery"></a>
 ### Nested Schema for `battery`

--- a/docs/resources/em1_config.md
+++ b/docs/resources/em1_config.md
@@ -22,6 +22,16 @@ description: |-
 
 ### Optional
 
+- `alarms` (Attributes) (see [below for nested schema](#nestedatt--alarms))
 - `ct_type` (String) Select the type of Shelly current transformer attached to the device.
 - `name` (String) Name of the EM1 instance
 - `reverse` (Boolean) Reverse CT measurement direction of active power and energy for the EM1 component. setting the reverse option requires restart
+
+<a id="nestedatt--alarms"></a>
+### Nested Schema for `alarms`
+
+Optional:
+
+- `current` (List of Number) ['under','over'] thresholds
+- `power` (List of Number) ['under','over'] thresholds
+- `voltage` (List of Number) ['under','over'] thresholds

--- a/docs/resources/em1data_config.md
+++ b/docs/resources/em1data_config.md
@@ -22,5 +22,6 @@ description: |-
 
 ### Optional
 
+- `errors` (List of String) Error condition occurred. May contain database_error or ct_type_not_set, (shown if the error is present).
 - `total_act_energy` (Number) Total active energy, Wh
 - `total_act_ret_energy` (Number) Total active returned energy, Wh

--- a/docs/resources/em_config.md
+++ b/docs/resources/em_config.md
@@ -22,12 +22,53 @@ description: |-
 
 ### Optional
 
+- `alarms` (Attributes) (see [below for nested schema](#nestedatt--alarms))
 - `blink_mode_selector` (String) Select the electrical quantity that drives the LED. Range of values: active_energy, apparent_energy
 - `ct_type` (String) Select the type of Shelly current transformer attached to the device.
 - `monitor_phase_sequence` (Boolean) Set this to show phase_sequence error in GetStatus if three-phase power system is used and the wires are not connected correctly to the device.
 - `name` (String) Name of the energy meter instance
 - `phase_selector` (String) Select witch phase controls the LED. Range of values: a, b, c, all
 - `reverse` (Attributes) (see [below for nested schema](#nestedatt--reverse))
+
+<a id="nestedatt--alarms"></a>
+### Nested Schema for `alarms`
+
+Optional:
+
+- `a` (Attributes) (see [below for nested schema](#nestedatt--alarms--a))
+- `b` (Attributes) (see [below for nested schema](#nestedatt--alarms--b))
+- `c` (Attributes) (see [below for nested schema](#nestedatt--alarms--c))
+
+<a id="nestedatt--alarms--a"></a>
+### Nested Schema for `alarms.a`
+
+Optional:
+
+- `current` (List of Number) ['under','over'] thresholds
+- `power` (List of Number) ['under','over'] thresholds
+- `voltage` (List of Number) ['under','over'] thresholds
+
+
+<a id="nestedatt--alarms--b"></a>
+### Nested Schema for `alarms.b`
+
+Optional:
+
+- `current` (List of Number) ['under','over'] thresholds
+- `power` (List of Number) ['under','over'] thresholds
+- `voltage` (List of Number) ['under','over'] thresholds
+
+
+<a id="nestedatt--alarms--c"></a>
+### Nested Schema for `alarms.c`
+
+Optional:
+
+- `current` (List of Number) ['under','over'] thresholds
+- `power` (List of Number) ['under','over'] thresholds
+- `voltage` (List of Number) ['under','over'] thresholds
+
+
 
 <a id="nestedatt--reverse"></a>
 ### Nested Schema for `reverse`

--- a/docs/resources/emdata_config.md
+++ b/docs/resources/emdata_config.md
@@ -28,5 +28,6 @@ description: |-
 - `b_total_act_ret_energy` (Number) Total active returned energy on phase B, Wh
 - `c_total_act_energy` (Number) Total active energy on phase C, Wh
 - `c_total_act_ret_energy` (Number) Total active returned energy on phase C, Wh
+- `errors` (List of String) Error condition occurred. May contain database_error or ct_type_not_set, (shown if the error is present).
 - `total_act` (Number) Total active energy on all phases, Wh
 - `total_act_ret` (Number) Total active returned energy on all phases, Wh

--- a/docs/resources/pm1_config.md
+++ b/docs/resources/pm1_config.md
@@ -22,5 +22,15 @@ description: |-
 
 ### Optional
 
+- `alarms` (Attributes) (see [below for nested schema](#nestedatt--alarms))
 - `name` (String) Name of the PM1 instance
 - `reverse` (Boolean) Reverse measurement direction of active power and energy for the PM1 component. setting the reverse option requires restart
+
+<a id="nestedatt--alarms"></a>
+### Nested Schema for `alarms`
+
+Optional:
+
+- `current` (List of Number) ['under','over'] thresholds
+- `power` (List of Number) ['under','over'] thresholds
+- `voltage` (List of Number) ['under','over'] thresholds

--- a/docs/resources/rgb_config.md
+++ b/docs/resources/rgb_config.md
@@ -51,6 +51,7 @@ Optional:
 Optional:
 
 - `brightness` (Number) Brightness level (in percent) set on double click (if applicable). null overrides brightness with current brightness when preset is applied. Default 100
+- `rgb` (List of Number) Color level set on double click (if applicable). Red, Green, Blue [r,g,b] - each value represents level between 0..255. null overrides rgb array with current rgb array when preset is applied. Default value 255 for each color
 
 
 
@@ -59,5 +60,7 @@ Optional:
 
 Optional:
 
+- `active_between` (List of String) Containing 2 elements of type string, the first element indicates the start of the period during which the night mode will be active, the second indicates the end of that period. Both start and end are strings in the format HH:MM, where HH and MM are hours and minutes with optinal leading zeros
 - `brightness` (Number) Brightness level limit (in percent) when night mode is active. null overrides night_mode.brightness with current brightness when night mode starts. Default value 50.
 - `enable` (Boolean) Enable or disable night mode
+- `rgb` (List of Number) Color level when night mode is active. Red, Green, Blue [r,g,b] - each value represents level between 0..255. null overrides night_mode.rgb array with current rgb array when night mode starts. Default value 255 for each color

--- a/docs/resources/rgbcct_config.md
+++ b/docs/resources/rgbcct_config.md
@@ -37,7 +37,9 @@ description: |-
 
 Optional:
 
+- `active_between` (List of String) Containing 2 elements of type string, the first element indicates the start of the period during which the night mode will be active, the second indicates the end of that period. Both start and end are strings in the format HH:MM, where HH and MM are hours and minutes with optinal leading zeros
 - `brightness` (Number) Brightness level limit (in percent) when night mode is active. null overrides night_mode.brightness with current brightness when night mode starts. Default value 50.
 - `ct` (Number) Color temperature level limit (in Kelvin) when night mode is active. null overrides night_mode.ct value with current ct value when night mode starts. Default value: 50% of ct_range. For DuoBulbG3: 4600
 - `enable` (Boolean) Enable or disable night mode
 - `mode` (String) Operating mode of the light output when night mode is active. Range of values: rgb, cct or null. null overrides night_mode.mode value with current mode when night mode starts. Default value: rgb
+- `rgb` (List of Number) Color level when night mode is active. Red, Green, Blue [r,g,b] - each value represents level between 0..255. null overrides night_mode.rgb array with current rgb array when night mode starts. Default value 255 for each color

--- a/docs/resources/rgbw_config.md
+++ b/docs/resources/rgbw_config.md
@@ -51,6 +51,7 @@ Optional:
 Optional:
 
 - `brightness` (Number) Brightness level (in percent) set on double click (if applicable). null overrides brightness with current brightness when preset is applied. Default 100
+- `rgb` (List of Number) Color level set on double click (if applicable). Red, Green, Blue [r,g,b] - each value represents level between 0..255. null overrides rgb array with current rgb array when preset is applied. Default value 255 for each color
 - `white` (Number) White level 0.255 set on double click (if applicable). null overrides white with current white when preset is applied. Default 255
 
 
@@ -60,6 +61,8 @@ Optional:
 
 Optional:
 
+- `active_between` (List of String) Containing 2 elements of type string, the first element indicates the start of the period during which the night mode will be active, the second indicates the end of that period. Both start and end are strings in the format HH:MM, where HH and MM are hours and minutes with optinal leading zeros
 - `brightness` (Number) Brightness level limit (in percent) when night mode is active. null overrides night_mode.brightness with current brightness when night mode starts. Default value 50.
 - `enable` (Boolean) Enable or disable night mode
+- `rgb` (List of Number) Color level when night mode is active. Red, Green, Blue [r,g,b] - each value represents level between 0..255. null overrides night_mode.rgb array with current rgb array when night mode starts. Default value 255 for each color
 - `white` (Number) White level limit (in percent) when night mode is active. null overrides night_mode.white with current white when night mode starts. Default value 127.

--- a/docs/resources/sys_config.md
+++ b/docs/resources/sys_config.md
@@ -87,12 +87,15 @@ Optional:
 - `discoverable` (Boolean) If true, device is shown in 'Discovered devices'. If false, the device is hidden.
 - `eco_mode` (Boolean) Experimental Decreases power consumption when set to true, at the cost of reduced execution speed and increased network latency
 - `enhanced_security` (Boolean) (Since 2.0.0) Read-only on devices shipped with firmware 2.0.0+ from factory (always true). On devices with factory firmware prior to 2.0.0, can be set to true but can only be reset to false via factory reset. When enabled, enforces additional security measures (see Enhanced Security section below).
-- `fw_id` (String) Read-only build identifier of the current firmware image
-- `mac` (String) Read-only base MAC address of the device
 - `name` (String) Name of the device
 - `profile` (String) Name of the device profile (only applicable for multi-profile devices)
 - `sys_btn_toggle` (Boolean) Enable/disable outputs toggle when the system (reset) button is pressed (shown if applicable).
 - `tls_check_cert_validity_time` (Boolean) (Since 2.0.0) When true, TLS certificate date/time validation is enforced for outbound connections. Can only be set to false when enhanced_security is false. This is a temporary option for users experiencing certificate validation issues due to time synchronization problems; subject to deprecation in future releases.
+
+Read-Only:
+
+- `fw_id` (String) Read-only build identifier of the current firmware image
+- `mac` (String) Read-only base MAC address of the device
 
 
 <a id="nestedatt--location"></a>

--- a/internal/provider/ble_config_resource_gen.go
+++ b/internal/provider/ble_config_resource_gen.go
@@ -59,32 +59,39 @@ func (r *bleConfigResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 	}
 }
 
+func (r *bleConfigResource) get(ctx context.Context, m *bleConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.BLEGetConfigRequest{}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.RPC != nil {
+		if m.RPC == nil {
+			m.RPC = &bleConfigRPCModel{}
+		}
+		if got.RPC.Enable != nil {
+			m.RPC.Enable = types.BoolValue(*got.RPC.Enable)
+		}
+	}
+}
+
 func (r *bleConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state bleConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.BLEGetConfigRequest{}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.RPC != nil {
-		if state.RPC == nil {
-			state.RPC = &bleConfigRPCModel{}
-		}
-		if got.RPC.Enable != nil {
-			state.RPC.Enable = types.BoolValue(*got.RPC.Enable)
-		}
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *bleConfigResource) apply(plan bleConfigResourceModel, diags *diag.Diagnostics) {
+func (r *bleConfigResource) apply(ctx context.Context, plan bleConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.BLEConfig
 	if plan.RPC != nil {
 		cfg.RPC = &components.BLEConfigRPC{}
@@ -107,7 +114,11 @@ func (r *bleConfigResource) Create(ctx context.Context, req resource.CreateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -120,7 +131,11 @@ func (r *bleConfigResource) Update(ctx context.Context, req resource.UpdateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/cct_config_resource_gen.go
+++ b/internal/provider/cct_config_resource_gen.go
@@ -203,90 +203,97 @@ func (r *cctConfigResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 	}
 }
 
+func (r *cctConfigResource) get(ctx context.Context, m *cctConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.CCTGetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Name != nil {
+		m.Name = types.StringValue(*got.Name)
+	}
+	if got.InitialState != nil {
+		m.InitialState = types.StringValue(*got.InitialState)
+	}
+	if got.AutoOn != nil {
+		m.AutoOn = types.BoolValue(*got.AutoOn)
+	}
+	if got.AutoOnDelay != nil {
+		m.AutoOnDelay = types.Float64Value(*got.AutoOnDelay)
+	}
+	if got.AutoOff != nil {
+		m.AutoOff = types.BoolValue(*got.AutoOff)
+	}
+	if got.AutoOffDelay != nil {
+		m.AutoOffDelay = types.Float64Value(*got.AutoOffDelay)
+	}
+	if got.TransitionDuration != nil {
+		m.TransitionDuration = types.Float64Value(*got.TransitionDuration)
+	}
+	if got.MinBrightnessOnToggle != nil {
+		m.MinBrightnessOnToggle = types.Float64Value(*got.MinBrightnessOnToggle)
+	}
+	if got.NightMode != nil {
+		if m.NightMode == nil {
+			m.NightMode = &cctConfigNightModeModel{}
+		}
+		if got.NightMode.Enable != nil {
+			m.NightMode.Enable = types.BoolValue(*got.NightMode.Enable)
+		}
+		if got.NightMode.Brightness != nil {
+			m.NightMode.Brightness = types.Float64Value(*got.NightMode.Brightness)
+		}
+		if got.NightMode.Ct != nil {
+			m.NightMode.Ct = types.Float64Value(*got.NightMode.Ct)
+		}
+	}
+	if got.ButtonFadeRate != nil {
+		m.ButtonFadeRate = types.Float64Value(*got.ButtonFadeRate)
+	}
+	if got.ButtonPresets != nil {
+		if m.ButtonPresets == nil {
+			m.ButtonPresets = &cctConfigButtonPresetsModel{}
+		}
+		if got.ButtonPresets.ButtonDoublepush != nil {
+			if m.ButtonPresets.ButtonDoublepush == nil {
+				m.ButtonPresets.ButtonDoublepush = &cctConfigButtonPresetsButtonDoublepushModel{}
+			}
+			if got.ButtonPresets.ButtonDoublepush.Brightness != nil {
+				m.ButtonPresets.ButtonDoublepush.Brightness = types.Float64Value(*got.ButtonPresets.ButtonDoublepush.Brightness)
+			}
+			if got.ButtonPresets.ButtonDoublepush.Ct != nil {
+				m.ButtonPresets.ButtonDoublepush.Ct = types.Float64Value(*got.ButtonPresets.ButtonDoublepush.Ct)
+			}
+		}
+	}
+	if got.CurrentLimit != nil {
+		m.CurrentLimit = types.Float64Value(*got.CurrentLimit)
+	}
+	if got.PowerLimit != nil {
+		m.PowerLimit = types.Float64Value(*got.PowerLimit)
+	}
+	if got.VoltageLimit != nil {
+		m.VoltageLimit = types.Float64Value(*got.VoltageLimit)
+	}
+}
+
 func (r *cctConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state cctConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.CCTGetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Name != nil {
-		state.Name = types.StringValue(*got.Name)
-	}
-	if got.InitialState != nil {
-		state.InitialState = types.StringValue(*got.InitialState)
-	}
-	if got.AutoOn != nil {
-		state.AutoOn = types.BoolValue(*got.AutoOn)
-	}
-	if got.AutoOnDelay != nil {
-		state.AutoOnDelay = types.Float64Value(*got.AutoOnDelay)
-	}
-	if got.AutoOff != nil {
-		state.AutoOff = types.BoolValue(*got.AutoOff)
-	}
-	if got.AutoOffDelay != nil {
-		state.AutoOffDelay = types.Float64Value(*got.AutoOffDelay)
-	}
-	if got.TransitionDuration != nil {
-		state.TransitionDuration = types.Float64Value(*got.TransitionDuration)
-	}
-	if got.MinBrightnessOnToggle != nil {
-		state.MinBrightnessOnToggle = types.Float64Value(*got.MinBrightnessOnToggle)
-	}
-	if got.NightMode != nil {
-		if state.NightMode == nil {
-			state.NightMode = &cctConfigNightModeModel{}
-		}
-		if got.NightMode.Enable != nil {
-			state.NightMode.Enable = types.BoolValue(*got.NightMode.Enable)
-		}
-		if got.NightMode.Brightness != nil {
-			state.NightMode.Brightness = types.Float64Value(*got.NightMode.Brightness)
-		}
-		if got.NightMode.Ct != nil {
-			state.NightMode.Ct = types.Float64Value(*got.NightMode.Ct)
-		}
-	}
-	if got.ButtonFadeRate != nil {
-		state.ButtonFadeRate = types.Float64Value(*got.ButtonFadeRate)
-	}
-	if got.ButtonPresets != nil {
-		if state.ButtonPresets == nil {
-			state.ButtonPresets = &cctConfigButtonPresetsModel{}
-		}
-		if got.ButtonPresets.ButtonDoublepush != nil {
-			if state.ButtonPresets.ButtonDoublepush == nil {
-				state.ButtonPresets.ButtonDoublepush = &cctConfigButtonPresetsButtonDoublepushModel{}
-			}
-			if got.ButtonPresets.ButtonDoublepush.Brightness != nil {
-				state.ButtonPresets.ButtonDoublepush.Brightness = types.Float64Value(*got.ButtonPresets.ButtonDoublepush.Brightness)
-			}
-			if got.ButtonPresets.ButtonDoublepush.Ct != nil {
-				state.ButtonPresets.ButtonDoublepush.Ct = types.Float64Value(*got.ButtonPresets.ButtonDoublepush.Ct)
-			}
-		}
-	}
-	if got.CurrentLimit != nil {
-		state.CurrentLimit = types.Float64Value(*got.CurrentLimit)
-	}
-	if got.PowerLimit != nil {
-		state.PowerLimit = types.Float64Value(*got.PowerLimit)
-	}
-	if got.VoltageLimit != nil {
-		state.VoltageLimit = types.Float64Value(*got.VoltageLimit)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *cctConfigResource) apply(plan cctConfigResourceModel, diags *diag.Diagnostics) {
+func (r *cctConfigResource) apply(ctx context.Context, plan cctConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.CCTConfig
 	cfg.ID = int(plan.ID.ValueInt64())
 	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
@@ -380,7 +387,11 @@ func (r *cctConfigResource) Create(ctx context.Context, req resource.CreateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -393,7 +404,11 @@ func (r *cctConfigResource) Update(ctx context.Context, req resource.UpdateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/cloud_config_resource_gen.go
+++ b/internal/provider/cloud_config_resource_gen.go
@@ -55,30 +55,37 @@ func (r *cloudConfigResource) Schema(_ context.Context, _ resource.SchemaRequest
 	}
 }
 
+func (r *cloudConfigResource) get(ctx context.Context, m *cloudConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.CloudGetConfigRequest{}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Enable != nil {
+		m.Enable = types.BoolValue(*got.Enable)
+	}
+	if got.Server != nil {
+		m.Server = types.StringValue(*got.Server)
+	}
+}
+
 func (r *cloudConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state cloudConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.CloudGetConfigRequest{}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Enable != nil {
-		state.Enable = types.BoolValue(*got.Enable)
-	}
-	if got.Server != nil {
-		state.Server = types.StringValue(*got.Server)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *cloudConfigResource) apply(plan cloudConfigResourceModel, diags *diag.Diagnostics) {
+func (r *cloudConfigResource) apply(ctx context.Context, plan cloudConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.CloudConfig
 	if !plan.Enable.IsNull() && !plan.Enable.IsUnknown() {
 		v := plan.Enable.ValueBool()
@@ -102,7 +109,11 @@ func (r *cloudConfigResource) Create(ctx context.Context, req resource.CreateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -115,7 +126,11 @@ func (r *cloudConfigResource) Update(ctx context.Context, req resource.UpdateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/cover_config_resource_gen.go
+++ b/internal/provider/cover_config_resource_gen.go
@@ -253,113 +253,120 @@ func (r *coverConfigResource) Schema(_ context.Context, _ resource.SchemaRequest
 	}
 }
 
+func (r *coverConfigResource) get(ctx context.Context, m *coverConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.CoverGetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Name != nil {
+		m.Name = types.StringValue(*got.Name)
+	}
+	if got.InLocked != nil {
+		m.InLocked = types.BoolValue(*got.InLocked)
+	}
+	if got.InitialState != nil {
+		m.InitialState = types.StringValue(*got.InitialState)
+	}
+	if got.PowerLimit != nil {
+		m.PowerLimit = types.Float64Value(*got.PowerLimit)
+	}
+	if got.VoltageLimit != nil {
+		m.VoltageLimit = types.Float64Value(*got.VoltageLimit)
+	}
+	if got.UndervoltageLimit != nil {
+		m.UndervoltageLimit = types.Float64Value(*got.UndervoltageLimit)
+	}
+	if got.CurrentLimit != nil {
+		m.CurrentLimit = types.Float64Value(*got.CurrentLimit)
+	}
+	if got.Motor != nil {
+		if m.Motor == nil {
+			m.Motor = &coverConfigMotorModel{}
+		}
+		if got.Motor.IdlePowerThr != nil {
+			m.Motor.IdlePowerThr = types.Float64Value(*got.Motor.IdlePowerThr)
+		}
+		if got.Motor.IdleConfirmPeriod != nil {
+			m.Motor.IdleConfirmPeriod = types.Float64Value(*got.Motor.IdleConfirmPeriod)
+		}
+	}
+	if got.MaxtimeOpen != nil {
+		m.MaxtimeOpen = types.Float64Value(*got.MaxtimeOpen)
+	}
+	if got.MaxtimeClose != nil {
+		m.MaxtimeClose = types.Float64Value(*got.MaxtimeClose)
+	}
+	if got.ObstructionDetection != nil {
+		if m.ObstructionDetection == nil {
+			m.ObstructionDetection = &coverConfigObstructionDetectionModel{}
+		}
+		if got.ObstructionDetection.Enable != nil {
+			m.ObstructionDetection.Enable = types.BoolValue(*got.ObstructionDetection.Enable)
+		}
+		if got.ObstructionDetection.Direction != nil {
+			m.ObstructionDetection.Direction = types.StringValue(*got.ObstructionDetection.Direction)
+		}
+		if got.ObstructionDetection.PowerThr != nil {
+			m.ObstructionDetection.PowerThr = types.Float64Value(*got.ObstructionDetection.PowerThr)
+		}
+		if got.ObstructionDetection.Holdoff != nil {
+			m.ObstructionDetection.Holdoff = types.Float64Value(*got.ObstructionDetection.Holdoff)
+		}
+	}
+	if got.SafetySwitch != nil {
+		if m.SafetySwitch == nil {
+			m.SafetySwitch = &coverConfigSafetySwitchModel{}
+		}
+		if got.SafetySwitch.Enable != nil {
+			m.SafetySwitch.Enable = types.BoolValue(*got.SafetySwitch.Enable)
+		}
+		if got.SafetySwitch.Direction != nil {
+			m.SafetySwitch.Direction = types.StringValue(*got.SafetySwitch.Direction)
+		}
+	}
+	if got.Slat != nil {
+		if m.Slat == nil {
+			m.Slat = &coverConfigSlatModel{}
+		}
+		if got.Slat.Enable != nil {
+			m.Slat.Enable = types.BoolValue(*got.Slat.Enable)
+		}
+		if got.Slat.OpenTime != nil {
+			m.Slat.OpenTime = types.Float64Value(*got.Slat.OpenTime)
+		}
+		if got.Slat.CloseTime != nil {
+			m.Slat.CloseTime = types.Float64Value(*got.Slat.CloseTime)
+		}
+		if got.Slat.Step != nil {
+			m.Slat.Step = types.Float64Value(*got.Slat.Step)
+		}
+		if got.Slat.RetainPos != nil {
+			m.Slat.RetainPos = types.BoolValue(*got.Slat.RetainPos)
+		}
+		if got.Slat.PreciseCtl != nil {
+			m.Slat.PreciseCtl = types.BoolValue(*got.Slat.PreciseCtl)
+		}
+	}
+}
+
 func (r *coverConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state coverConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.CoverGetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Name != nil {
-		state.Name = types.StringValue(*got.Name)
-	}
-	if got.InLocked != nil {
-		state.InLocked = types.BoolValue(*got.InLocked)
-	}
-	if got.InitialState != nil {
-		state.InitialState = types.StringValue(*got.InitialState)
-	}
-	if got.PowerLimit != nil {
-		state.PowerLimit = types.Float64Value(*got.PowerLimit)
-	}
-	if got.VoltageLimit != nil {
-		state.VoltageLimit = types.Float64Value(*got.VoltageLimit)
-	}
-	if got.UndervoltageLimit != nil {
-		state.UndervoltageLimit = types.Float64Value(*got.UndervoltageLimit)
-	}
-	if got.CurrentLimit != nil {
-		state.CurrentLimit = types.Float64Value(*got.CurrentLimit)
-	}
-	if got.Motor != nil {
-		if state.Motor == nil {
-			state.Motor = &coverConfigMotorModel{}
-		}
-		if got.Motor.IdlePowerThr != nil {
-			state.Motor.IdlePowerThr = types.Float64Value(*got.Motor.IdlePowerThr)
-		}
-		if got.Motor.IdleConfirmPeriod != nil {
-			state.Motor.IdleConfirmPeriod = types.Float64Value(*got.Motor.IdleConfirmPeriod)
-		}
-	}
-	if got.MaxtimeOpen != nil {
-		state.MaxtimeOpen = types.Float64Value(*got.MaxtimeOpen)
-	}
-	if got.MaxtimeClose != nil {
-		state.MaxtimeClose = types.Float64Value(*got.MaxtimeClose)
-	}
-	if got.ObstructionDetection != nil {
-		if state.ObstructionDetection == nil {
-			state.ObstructionDetection = &coverConfigObstructionDetectionModel{}
-		}
-		if got.ObstructionDetection.Enable != nil {
-			state.ObstructionDetection.Enable = types.BoolValue(*got.ObstructionDetection.Enable)
-		}
-		if got.ObstructionDetection.Direction != nil {
-			state.ObstructionDetection.Direction = types.StringValue(*got.ObstructionDetection.Direction)
-		}
-		if got.ObstructionDetection.PowerThr != nil {
-			state.ObstructionDetection.PowerThr = types.Float64Value(*got.ObstructionDetection.PowerThr)
-		}
-		if got.ObstructionDetection.Holdoff != nil {
-			state.ObstructionDetection.Holdoff = types.Float64Value(*got.ObstructionDetection.Holdoff)
-		}
-	}
-	if got.SafetySwitch != nil {
-		if state.SafetySwitch == nil {
-			state.SafetySwitch = &coverConfigSafetySwitchModel{}
-		}
-		if got.SafetySwitch.Enable != nil {
-			state.SafetySwitch.Enable = types.BoolValue(*got.SafetySwitch.Enable)
-		}
-		if got.SafetySwitch.Direction != nil {
-			state.SafetySwitch.Direction = types.StringValue(*got.SafetySwitch.Direction)
-		}
-	}
-	if got.Slat != nil {
-		if state.Slat == nil {
-			state.Slat = &coverConfigSlatModel{}
-		}
-		if got.Slat.Enable != nil {
-			state.Slat.Enable = types.BoolValue(*got.Slat.Enable)
-		}
-		if got.Slat.OpenTime != nil {
-			state.Slat.OpenTime = types.Float64Value(*got.Slat.OpenTime)
-		}
-		if got.Slat.CloseTime != nil {
-			state.Slat.CloseTime = types.Float64Value(*got.Slat.CloseTime)
-		}
-		if got.Slat.Step != nil {
-			state.Slat.Step = types.Float64Value(*got.Slat.Step)
-		}
-		if got.Slat.RetainPos != nil {
-			state.Slat.RetainPos = types.BoolValue(*got.Slat.RetainPos)
-		}
-		if got.Slat.PreciseCtl != nil {
-			state.Slat.PreciseCtl = types.BoolValue(*got.Slat.PreciseCtl)
-		}
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *coverConfigResource) apply(plan coverConfigResourceModel, diags *diag.Diagnostics) {
+func (r *coverConfigResource) apply(ctx context.Context, plan coverConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.CoverConfig
 	cfg.ID = int(plan.ID.ValueInt64())
 	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
@@ -480,7 +487,11 @@ func (r *coverConfigResource) Create(ctx context.Context, req resource.CreateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -493,7 +504,11 @@ func (r *coverConfigResource) Update(ctx context.Context, req resource.UpdateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/dali_config_resource_gen.go
+++ b/internal/provider/dali_config_resource_gen.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -34,6 +35,7 @@ type daliConfigResourceModel struct {
 	IP      types.String         `tfsdk:"ip"`
 	CgCount types.Float64        `tfsdk:"cg_count"`
 	Scan    *daliConfigScanModel `tfsdk:"scan"`
+	Errors  types.List           `tfsdk:"errors"`
 }
 
 func (r *daliConfigResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -69,7 +71,44 @@ func (r *daliConfigResource) Schema(_ context.Context, _ resource.SchemaRequest,
 					},
 				},
 			},
+			"errors": schema.ListAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Shown only if at least one error is present. May contain control_gear_missing, driver",
+				PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+			},
 		},
+	}
+}
+
+func (r *daliConfigResource) get(ctx context.Context, m *daliConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.DALIGetConfigRequest{}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.CgCount != nil {
+		m.CgCount = types.Float64Value(*got.CgCount)
+	}
+	if got.Scan != nil {
+		if m.Scan == nil {
+			m.Scan = &daliConfigScanModel{}
+		}
+		if got.Scan.CgCount != nil {
+			m.Scan.CgCount = types.Float64Value(*got.Scan.CgCount)
+		}
+		if got.Scan.StartedAt != nil {
+			m.Scan.StartedAt = types.Float64Value(*got.Scan.StartedAt)
+		}
+	}
+	if got.Errors != nil {
+		l, d := types.ListValueFrom(ctx, types.StringType, got.Errors)
+		diags.Append(d...)
+		m.Errors = l
 	}
 }
 
@@ -79,32 +118,14 @@ func (r *daliConfigResource) Read(ctx context.Context, req resource.ReadRequest,
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.DALIGetConfigRequest{}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.CgCount != nil {
-		state.CgCount = types.Float64Value(*got.CgCount)
-	}
-	if got.Scan != nil {
-		if state.Scan == nil {
-			state.Scan = &daliConfigScanModel{}
-		}
-		if got.Scan.CgCount != nil {
-			state.Scan.CgCount = types.Float64Value(*got.Scan.CgCount)
-		}
-		if got.Scan.StartedAt != nil {
-			state.Scan.StartedAt = types.Float64Value(*got.Scan.StartedAt)
-		}
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *daliConfigResource) apply(plan daliConfigResourceModel, diags *diag.Diagnostics) {
+func (r *daliConfigResource) apply(ctx context.Context, plan daliConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.DALIConfig
 	if !plan.CgCount.IsNull() && !plan.CgCount.IsUnknown() {
 		v := plan.CgCount.ValueFloat64()
@@ -121,6 +142,11 @@ func (r *daliConfigResource) apply(plan daliConfigResourceModel, diags *diag.Dia
 			cfg.Scan.StartedAt = &v
 		}
 	}
+	if !plan.Errors.IsNull() && !plan.Errors.IsUnknown() {
+		var v []string
+		diags.Append(plan.Errors.ElementsAs(ctx, &v, false)...)
+		cfg.Errors = v
+	}
 	client := resty.New()
 	defer client.Close()
 	client.SetBaseURL("http://" + plan.IP.ValueString())
@@ -135,7 +161,11 @@ func (r *daliConfigResource) Create(ctx context.Context, req resource.CreateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -148,7 +178,11 @@ func (r *daliConfigResource) Update(ctx context.Context, req resource.UpdateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/devicepower_config_resource_gen.go
+++ b/internal/provider/devicepower_config_resource_gen.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -36,6 +37,7 @@ type devicepowerConfigResourceModel struct {
 	IP      types.String                   `tfsdk:"ip"`
 	ID      types.Int64                    `tfsdk:"id"`
 	Battery *devicepowerConfigBatteryModel `tfsdk:"battery"`
+	Errors  types.List                     `tfsdk:"errors"`
 }
 
 func (r *devicepowerConfigResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -60,7 +62,38 @@ func (r *devicepowerConfigResource) Schema(_ context.Context, _ resource.SchemaR
 					},
 				},
 			},
+			"errors": schema.ListAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Whether external power source is connected",
+				PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+			},
 		},
+	}
+}
+
+func (r *devicepowerConfigResource) get(ctx context.Context, m *devicepowerConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.DevicePowerGetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Battery != nil {
+		if m.Battery == nil {
+			m.Battery = &devicepowerConfigBatteryModel{}
+		}
+		if got.Battery.Percent != nil {
+			m.Battery.Percent = types.Float64Value(*got.Battery.Percent)
+		}
+	}
+	if got.Errors != nil {
+		l, d := types.ListValueFrom(ctx, types.StringType, got.Errors)
+		diags.Append(d...)
+		m.Errors = l
 	}
 }
 
@@ -70,26 +103,14 @@ func (r *devicepowerConfigResource) Read(ctx context.Context, req resource.ReadR
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.DevicePowerGetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Battery != nil {
-		if state.Battery == nil {
-			state.Battery = &devicepowerConfigBatteryModel{}
-		}
-		if got.Battery.Percent != nil {
-			state.Battery.Percent = types.Float64Value(*got.Battery.Percent)
-		}
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *devicepowerConfigResource) apply(plan devicepowerConfigResourceModel, diags *diag.Diagnostics) {
+func (r *devicepowerConfigResource) apply(ctx context.Context, plan devicepowerConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.DevicePowerConfig
 	cfg.ID = int(plan.ID.ValueInt64())
 	if plan.Battery != nil {
@@ -98,6 +119,11 @@ func (r *devicepowerConfigResource) apply(plan devicepowerConfigResourceModel, d
 			v := plan.Battery.Percent.ValueFloat64()
 			cfg.Battery.Percent = &v
 		}
+	}
+	if !plan.Errors.IsNull() && !plan.Errors.IsUnknown() {
+		var v []string
+		diags.Append(plan.Errors.ElementsAs(ctx, &v, false)...)
+		cfg.Errors = v
 	}
 	client := resty.New()
 	defer client.Close()
@@ -113,7 +139,11 @@ func (r *devicepowerConfigResource) Create(ctx context.Context, req resource.Cre
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -126,7 +156,11 @@ func (r *devicepowerConfigResource) Update(ctx context.Context, req resource.Upd
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/em1_config_resource_gen.go
+++ b/internal/provider/em1_config_resource_gen.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -28,12 +30,19 @@ func NewEM1ConfigResource() resource.Resource { return &em1ConfigResource{} }
 
 type em1ConfigResource struct{}
 
+type em1ConfigAlarmsModel struct {
+	Voltage types.List `tfsdk:"voltage"`
+	Current types.List `tfsdk:"current"`
+	Power   types.List `tfsdk:"power"`
+}
+
 type em1ConfigResourceModel struct {
-	IP      types.String `tfsdk:"ip"`
-	ID      types.Int64  `tfsdk:"id"`
-	Name    types.String `tfsdk:"name"`
-	Reverse types.Bool   `tfsdk:"reverse"`
-	CtType  types.String `tfsdk:"ct_type"`
+	IP      types.String          `tfsdk:"ip"`
+	ID      types.Int64           `tfsdk:"id"`
+	Name    types.String          `tfsdk:"name"`
+	Reverse types.Bool            `tfsdk:"reverse"`
+	CtType  types.String          `tfsdk:"ct_type"`
+	Alarms  *em1ConfigAlarmsModel `tfsdk:"alarms"`
 }
 
 func (r *em1ConfigResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -63,7 +72,75 @@ func (r *em1ConfigResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				MarkdownDescription: "Select the type of Shelly current transformer attached to the device.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
+			"alarms": schema.SingleNestedAttribute{
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
+				Attributes: map[string]schema.Attribute{
+					"voltage": schema.ListAttribute{
+						ElementType:         types.Float64Type,
+						Optional:            true,
+						Computed:            true,
+						MarkdownDescription: "['under','over'] thresholds",
+						PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+					},
+					"current": schema.ListAttribute{
+						ElementType:         types.Float64Type,
+						Optional:            true,
+						Computed:            true,
+						MarkdownDescription: "['under','over'] thresholds",
+						PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+					},
+					"power": schema.ListAttribute{
+						ElementType:         types.Float64Type,
+						Optional:            true,
+						Computed:            true,
+						MarkdownDescription: "['under','over'] thresholds",
+						PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+					},
+				},
+			},
 		},
+	}
+}
+
+func (r *em1ConfigResource) get(ctx context.Context, m *em1ConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.EM1GetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Name != nil {
+		m.Name = types.StringValue(*got.Name)
+	}
+	if got.Reverse != nil {
+		m.Reverse = types.BoolValue(*got.Reverse)
+	}
+	if got.CtType != nil {
+		m.CtType = types.StringValue(*got.CtType)
+	}
+	if got.Alarms != nil {
+		if m.Alarms == nil {
+			m.Alarms = &em1ConfigAlarmsModel{}
+		}
+		if got.Alarms.Voltage != nil {
+			l, d := types.ListValueFrom(ctx, types.Float64Type, got.Alarms.Voltage)
+			diags.Append(d...)
+			m.Alarms.Voltage = l
+		}
+		if got.Alarms.Current != nil {
+			l, d := types.ListValueFrom(ctx, types.Float64Type, got.Alarms.Current)
+			diags.Append(d...)
+			m.Alarms.Current = l
+		}
+		if got.Alarms.Power != nil {
+			l, d := types.ListValueFrom(ctx, types.Float64Type, got.Alarms.Power)
+			diags.Append(d...)
+			m.Alarms.Power = l
+		}
 	}
 }
 
@@ -73,27 +150,14 @@ func (r *em1ConfigResource) Read(ctx context.Context, req resource.ReadRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.EM1GetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Name != nil {
-		state.Name = types.StringValue(*got.Name)
-	}
-	if got.Reverse != nil {
-		state.Reverse = types.BoolValue(*got.Reverse)
-	}
-	if got.CtType != nil {
-		state.CtType = types.StringValue(*got.CtType)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *em1ConfigResource) apply(plan em1ConfigResourceModel, diags *diag.Diagnostics) {
+func (r *em1ConfigResource) apply(ctx context.Context, plan em1ConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.EM1Config
 	cfg.ID = int(plan.ID.ValueInt64())
 	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
@@ -107,6 +171,24 @@ func (r *em1ConfigResource) apply(plan em1ConfigResourceModel, diags *diag.Diagn
 	if !plan.CtType.IsNull() && !plan.CtType.IsUnknown() {
 		v := plan.CtType.ValueString()
 		cfg.CtType = &v
+	}
+	if plan.Alarms != nil {
+		cfg.Alarms = &components.EM1ConfigAlarms{}
+		if !plan.Alarms.Voltage.IsNull() && !plan.Alarms.Voltage.IsUnknown() {
+			var v []float64
+			diags.Append(plan.Alarms.Voltage.ElementsAs(ctx, &v, false)...)
+			cfg.Alarms.Voltage = v
+		}
+		if !plan.Alarms.Current.IsNull() && !plan.Alarms.Current.IsUnknown() {
+			var v []float64
+			diags.Append(plan.Alarms.Current.ElementsAs(ctx, &v, false)...)
+			cfg.Alarms.Current = v
+		}
+		if !plan.Alarms.Power.IsNull() && !plan.Alarms.Power.IsUnknown() {
+			var v []float64
+			diags.Append(plan.Alarms.Power.ElementsAs(ctx, &v, false)...)
+			cfg.Alarms.Power = v
+		}
 	}
 	client := resty.New()
 	defer client.Close()
@@ -122,7 +204,11 @@ func (r *em1ConfigResource) Create(ctx context.Context, req resource.CreateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -135,7 +221,11 @@ func (r *em1ConfigResource) Update(ctx context.Context, req resource.UpdateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/em1data_config_resource_gen.go
+++ b/internal/provider/em1data_config_resource_gen.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"resty.dev/v3"
@@ -32,6 +33,7 @@ type em1dataConfigResourceModel struct {
 	ID                types.Int64   `tfsdk:"id"`
 	TotalActEnergy    types.Float64 `tfsdk:"total_act_energy"`
 	TotalActRetEnergy types.Float64 `tfsdk:"total_act_ret_energy"`
+	Errors            types.List    `tfsdk:"errors"`
 }
 
 func (r *em1dataConfigResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -55,7 +57,36 @@ func (r *em1dataConfigResource) Schema(_ context.Context, _ resource.SchemaReque
 				MarkdownDescription: "Total active returned energy, Wh",
 				PlanModifiers:       []planmodifier.Float64{float64planmodifier.UseStateForUnknown()},
 			},
+			"errors": schema.ListAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Error condition occurred. May contain database_error or ct_type_not_set, (shown if the error is present).",
+				PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+			},
 		},
+	}
+}
+
+func (r *em1dataConfigResource) get(ctx context.Context, m *em1dataConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.EM1DataGetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.TotalActEnergy != nil {
+		m.TotalActEnergy = types.Float64Value(*got.TotalActEnergy)
+	}
+	if got.TotalActRetEnergy != nil {
+		m.TotalActRetEnergy = types.Float64Value(*got.TotalActRetEnergy)
+	}
+	if got.Errors != nil {
+		l, d := types.ListValueFrom(ctx, types.StringType, got.Errors)
+		diags.Append(d...)
+		m.Errors = l
 	}
 }
 
@@ -65,24 +96,14 @@ func (r *em1dataConfigResource) Read(ctx context.Context, req resource.ReadReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.EM1DataGetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.TotalActEnergy != nil {
-		state.TotalActEnergy = types.Float64Value(*got.TotalActEnergy)
-	}
-	if got.TotalActRetEnergy != nil {
-		state.TotalActRetEnergy = types.Float64Value(*got.TotalActRetEnergy)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *em1dataConfigResource) apply(plan em1dataConfigResourceModel, diags *diag.Diagnostics) {
+func (r *em1dataConfigResource) apply(ctx context.Context, plan em1dataConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.EM1DataConfig
 	cfg.ID = int(plan.ID.ValueInt64())
 	if !plan.TotalActEnergy.IsNull() && !plan.TotalActEnergy.IsUnknown() {
@@ -92,6 +113,11 @@ func (r *em1dataConfigResource) apply(plan em1dataConfigResourceModel, diags *di
 	if !plan.TotalActRetEnergy.IsNull() && !plan.TotalActRetEnergy.IsUnknown() {
 		v := plan.TotalActRetEnergy.ValueFloat64()
 		cfg.TotalActRetEnergy = &v
+	}
+	if !plan.Errors.IsNull() && !plan.Errors.IsUnknown() {
+		var v []string
+		diags.Append(plan.Errors.ElementsAs(ctx, &v, false)...)
+		cfg.Errors = v
 	}
 	client := resty.New()
 	defer client.Close()
@@ -107,7 +133,11 @@ func (r *em1dataConfigResource) Create(ctx context.Context, req resource.CreateR
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -120,7 +150,11 @@ func (r *em1dataConfigResource) Update(ctx context.Context, req resource.UpdateR
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/em_config_resource_gen.go
+++ b/internal/provider/em_config_resource_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -37,6 +38,30 @@ type emConfigReverseModel struct {
 	C types.Bool `tfsdk:"c"`
 }
 
+type emConfigAlarmsAModel struct {
+	Voltage types.List `tfsdk:"voltage"`
+	Current types.List `tfsdk:"current"`
+	Power   types.List `tfsdk:"power"`
+}
+
+type emConfigAlarmsBModel struct {
+	Voltage types.List `tfsdk:"voltage"`
+	Current types.List `tfsdk:"current"`
+	Power   types.List `tfsdk:"power"`
+}
+
+type emConfigAlarmsCModel struct {
+	Voltage types.List `tfsdk:"voltage"`
+	Current types.List `tfsdk:"current"`
+	Power   types.List `tfsdk:"power"`
+}
+
+type emConfigAlarmsModel struct {
+	A *emConfigAlarmsAModel `tfsdk:"a"`
+	B *emConfigAlarmsBModel `tfsdk:"b"`
+	C *emConfigAlarmsCModel `tfsdk:"c"`
+}
+
 type emConfigResourceModel struct {
 	IP                   types.String          `tfsdk:"ip"`
 	ID                   types.Int64           `tfsdk:"id"`
@@ -45,6 +70,7 @@ type emConfigResourceModel struct {
 	PhaseSelector        types.String          `tfsdk:"phase_selector"`
 	MonitorPhaseSequence types.Bool            `tfsdk:"monitor_phase_sequence"`
 	Reverse              *emConfigReverseModel `tfsdk:"reverse"`
+	Alarms               *emConfigAlarmsModel  `tfsdk:"alarms"`
 	CtType               types.String          `tfsdk:"ct_type"`
 }
 
@@ -108,6 +134,97 @@ func (r *emConfigResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 					},
 				},
 			},
+			"alarms": schema.SingleNestedAttribute{
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
+				Attributes: map[string]schema.Attribute{
+					"a": schema.SingleNestedAttribute{
+						Optional:      true,
+						Computed:      true,
+						PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
+						Attributes: map[string]schema.Attribute{
+							"voltage": schema.ListAttribute{
+								ElementType:         types.Float64Type,
+								Optional:            true,
+								Computed:            true,
+								MarkdownDescription: "['under','over'] thresholds",
+								PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+							},
+							"current": schema.ListAttribute{
+								ElementType:         types.Float64Type,
+								Optional:            true,
+								Computed:            true,
+								MarkdownDescription: "['under','over'] thresholds",
+								PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+							},
+							"power": schema.ListAttribute{
+								ElementType:         types.Float64Type,
+								Optional:            true,
+								Computed:            true,
+								MarkdownDescription: "['under','over'] thresholds",
+								PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+							},
+						},
+					},
+					"b": schema.SingleNestedAttribute{
+						Optional:      true,
+						Computed:      true,
+						PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
+						Attributes: map[string]schema.Attribute{
+							"voltage": schema.ListAttribute{
+								ElementType:         types.Float64Type,
+								Optional:            true,
+								Computed:            true,
+								MarkdownDescription: "['under','over'] thresholds",
+								PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+							},
+							"current": schema.ListAttribute{
+								ElementType:         types.Float64Type,
+								Optional:            true,
+								Computed:            true,
+								MarkdownDescription: "['under','over'] thresholds",
+								PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+							},
+							"power": schema.ListAttribute{
+								ElementType:         types.Float64Type,
+								Optional:            true,
+								Computed:            true,
+								MarkdownDescription: "['under','over'] thresholds",
+								PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+							},
+						},
+					},
+					"c": schema.SingleNestedAttribute{
+						Optional:      true,
+						Computed:      true,
+						PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
+						Attributes: map[string]schema.Attribute{
+							"voltage": schema.ListAttribute{
+								ElementType:         types.Float64Type,
+								Optional:            true,
+								Computed:            true,
+								MarkdownDescription: "['under','over'] thresholds",
+								PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+							},
+							"current": schema.ListAttribute{
+								ElementType:         types.Float64Type,
+								Optional:            true,
+								Computed:            true,
+								MarkdownDescription: "['under','over'] thresholds",
+								PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+							},
+							"power": schema.ListAttribute{
+								ElementType:         types.Float64Type,
+								Optional:            true,
+								Computed:            true,
+								MarkdownDescription: "['under','over'] thresholds",
+								PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+							},
+						},
+					},
+				},
+			},
 			"ct_type": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
@@ -118,53 +235,125 @@ func (r *emConfigResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 	}
 }
 
+func (r *emConfigResource) get(ctx context.Context, m *emConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.EMGetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Name != nil {
+		m.Name = types.StringValue(*got.Name)
+	}
+	if got.BlinkModeSelector != nil {
+		m.BlinkModeSelector = types.StringValue(*got.BlinkModeSelector)
+	}
+	if got.PhaseSelector != nil {
+		m.PhaseSelector = types.StringValue(*got.PhaseSelector)
+	}
+	if got.MonitorPhaseSequence != nil {
+		m.MonitorPhaseSequence = types.BoolValue(*got.MonitorPhaseSequence)
+	}
+	if got.Reverse != nil {
+		if m.Reverse == nil {
+			m.Reverse = &emConfigReverseModel{}
+		}
+		if got.Reverse.A != nil {
+			m.Reverse.A = types.BoolValue(*got.Reverse.A)
+		}
+		if got.Reverse.B != nil {
+			m.Reverse.B = types.BoolValue(*got.Reverse.B)
+		}
+		if got.Reverse.C != nil {
+			m.Reverse.C = types.BoolValue(*got.Reverse.C)
+		}
+	}
+	if got.Alarms != nil {
+		if m.Alarms == nil {
+			m.Alarms = &emConfigAlarmsModel{}
+		}
+		if got.Alarms.A != nil {
+			if m.Alarms.A == nil {
+				m.Alarms.A = &emConfigAlarmsAModel{}
+			}
+			if got.Alarms.A.Voltage != nil {
+				l, d := types.ListValueFrom(ctx, types.Float64Type, got.Alarms.A.Voltage)
+				diags.Append(d...)
+				m.Alarms.A.Voltage = l
+			}
+			if got.Alarms.A.Current != nil {
+				l, d := types.ListValueFrom(ctx, types.Float64Type, got.Alarms.A.Current)
+				diags.Append(d...)
+				m.Alarms.A.Current = l
+			}
+			if got.Alarms.A.Power != nil {
+				l, d := types.ListValueFrom(ctx, types.Float64Type, got.Alarms.A.Power)
+				diags.Append(d...)
+				m.Alarms.A.Power = l
+			}
+		}
+		if got.Alarms.B != nil {
+			if m.Alarms.B == nil {
+				m.Alarms.B = &emConfigAlarmsBModel{}
+			}
+			if got.Alarms.B.Voltage != nil {
+				l, d := types.ListValueFrom(ctx, types.Float64Type, got.Alarms.B.Voltage)
+				diags.Append(d...)
+				m.Alarms.B.Voltage = l
+			}
+			if got.Alarms.B.Current != nil {
+				l, d := types.ListValueFrom(ctx, types.Float64Type, got.Alarms.B.Current)
+				diags.Append(d...)
+				m.Alarms.B.Current = l
+			}
+			if got.Alarms.B.Power != nil {
+				l, d := types.ListValueFrom(ctx, types.Float64Type, got.Alarms.B.Power)
+				diags.Append(d...)
+				m.Alarms.B.Power = l
+			}
+		}
+		if got.Alarms.C != nil {
+			if m.Alarms.C == nil {
+				m.Alarms.C = &emConfigAlarmsCModel{}
+			}
+			if got.Alarms.C.Voltage != nil {
+				l, d := types.ListValueFrom(ctx, types.Float64Type, got.Alarms.C.Voltage)
+				diags.Append(d...)
+				m.Alarms.C.Voltage = l
+			}
+			if got.Alarms.C.Current != nil {
+				l, d := types.ListValueFrom(ctx, types.Float64Type, got.Alarms.C.Current)
+				diags.Append(d...)
+				m.Alarms.C.Current = l
+			}
+			if got.Alarms.C.Power != nil {
+				l, d := types.ListValueFrom(ctx, types.Float64Type, got.Alarms.C.Power)
+				diags.Append(d...)
+				m.Alarms.C.Power = l
+			}
+		}
+	}
+	if got.CtType != nil {
+		m.CtType = types.StringValue(*got.CtType)
+	}
+}
+
 func (r *emConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state emConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.EMGetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Name != nil {
-		state.Name = types.StringValue(*got.Name)
-	}
-	if got.BlinkModeSelector != nil {
-		state.BlinkModeSelector = types.StringValue(*got.BlinkModeSelector)
-	}
-	if got.PhaseSelector != nil {
-		state.PhaseSelector = types.StringValue(*got.PhaseSelector)
-	}
-	if got.MonitorPhaseSequence != nil {
-		state.MonitorPhaseSequence = types.BoolValue(*got.MonitorPhaseSequence)
-	}
-	if got.Reverse != nil {
-		if state.Reverse == nil {
-			state.Reverse = &emConfigReverseModel{}
-		}
-		if got.Reverse.A != nil {
-			state.Reverse.A = types.BoolValue(*got.Reverse.A)
-		}
-		if got.Reverse.B != nil {
-			state.Reverse.B = types.BoolValue(*got.Reverse.B)
-		}
-		if got.Reverse.C != nil {
-			state.Reverse.C = types.BoolValue(*got.Reverse.C)
-		}
-	}
-	if got.CtType != nil {
-		state.CtType = types.StringValue(*got.CtType)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *emConfigResource) apply(plan emConfigResourceModel, diags *diag.Diagnostics) {
+func (r *emConfigResource) apply(ctx context.Context, plan emConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.EMConfig
 	cfg.ID = int(plan.ID.ValueInt64())
 	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
@@ -198,6 +387,63 @@ func (r *emConfigResource) apply(plan emConfigResourceModel, diags *diag.Diagnos
 			cfg.Reverse.C = &v
 		}
 	}
+	if plan.Alarms != nil {
+		cfg.Alarms = &components.EMConfigAlarms{}
+		if plan.Alarms.A != nil {
+			cfg.Alarms.A = &components.EMConfigAlarmsA{}
+			if !plan.Alarms.A.Voltage.IsNull() && !plan.Alarms.A.Voltage.IsUnknown() {
+				var v []float64
+				diags.Append(plan.Alarms.A.Voltage.ElementsAs(ctx, &v, false)...)
+				cfg.Alarms.A.Voltage = v
+			}
+			if !plan.Alarms.A.Current.IsNull() && !plan.Alarms.A.Current.IsUnknown() {
+				var v []float64
+				diags.Append(plan.Alarms.A.Current.ElementsAs(ctx, &v, false)...)
+				cfg.Alarms.A.Current = v
+			}
+			if !plan.Alarms.A.Power.IsNull() && !plan.Alarms.A.Power.IsUnknown() {
+				var v []float64
+				diags.Append(plan.Alarms.A.Power.ElementsAs(ctx, &v, false)...)
+				cfg.Alarms.A.Power = v
+			}
+		}
+		if plan.Alarms.B != nil {
+			cfg.Alarms.B = &components.EMConfigAlarmsB{}
+			if !plan.Alarms.B.Voltage.IsNull() && !plan.Alarms.B.Voltage.IsUnknown() {
+				var v []float64
+				diags.Append(plan.Alarms.B.Voltage.ElementsAs(ctx, &v, false)...)
+				cfg.Alarms.B.Voltage = v
+			}
+			if !plan.Alarms.B.Current.IsNull() && !plan.Alarms.B.Current.IsUnknown() {
+				var v []float64
+				diags.Append(plan.Alarms.B.Current.ElementsAs(ctx, &v, false)...)
+				cfg.Alarms.B.Current = v
+			}
+			if !plan.Alarms.B.Power.IsNull() && !plan.Alarms.B.Power.IsUnknown() {
+				var v []float64
+				diags.Append(plan.Alarms.B.Power.ElementsAs(ctx, &v, false)...)
+				cfg.Alarms.B.Power = v
+			}
+		}
+		if plan.Alarms.C != nil {
+			cfg.Alarms.C = &components.EMConfigAlarmsC{}
+			if !plan.Alarms.C.Voltage.IsNull() && !plan.Alarms.C.Voltage.IsUnknown() {
+				var v []float64
+				diags.Append(plan.Alarms.C.Voltage.ElementsAs(ctx, &v, false)...)
+				cfg.Alarms.C.Voltage = v
+			}
+			if !plan.Alarms.C.Current.IsNull() && !plan.Alarms.C.Current.IsUnknown() {
+				var v []float64
+				diags.Append(plan.Alarms.C.Current.ElementsAs(ctx, &v, false)...)
+				cfg.Alarms.C.Current = v
+			}
+			if !plan.Alarms.C.Power.IsNull() && !plan.Alarms.C.Power.IsUnknown() {
+				var v []float64
+				diags.Append(plan.Alarms.C.Power.ElementsAs(ctx, &v, false)...)
+				cfg.Alarms.C.Power = v
+			}
+		}
+	}
 	if !plan.CtType.IsNull() && !plan.CtType.IsUnknown() {
 		v := plan.CtType.ValueString()
 		cfg.CtType = &v
@@ -216,7 +462,11 @@ func (r *emConfigResource) Create(ctx context.Context, req resource.CreateReques
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -229,7 +479,11 @@ func (r *emConfigResource) Update(ctx context.Context, req resource.UpdateReques
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/emdata_config_resource_gen.go
+++ b/internal/provider/emdata_config_resource_gen.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"resty.dev/v3"
@@ -38,6 +39,7 @@ type emdataConfigResourceModel struct {
 	CTotalActRetEnergy types.Float64 `tfsdk:"c_total_act_ret_energy"`
 	TotalAct           types.Float64 `tfsdk:"total_act"`
 	TotalActRet        types.Float64 `tfsdk:"total_act_ret"`
+	Errors             types.List    `tfsdk:"errors"`
 }
 
 func (r *emdataConfigResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -97,7 +99,54 @@ func (r *emdataConfigResource) Schema(_ context.Context, _ resource.SchemaReques
 				MarkdownDescription: "Total active returned energy on all phases, Wh",
 				PlanModifiers:       []planmodifier.Float64{float64planmodifier.UseStateForUnknown()},
 			},
+			"errors": schema.ListAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Error condition occurred. May contain database_error or ct_type_not_set, (shown if the error is present).",
+				PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+			},
 		},
+	}
+}
+
+func (r *emdataConfigResource) get(ctx context.Context, m *emdataConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.EMDataGetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.ATotalActEnergy != nil {
+		m.ATotalActEnergy = types.Float64Value(*got.ATotalActEnergy)
+	}
+	if got.ATotalActRetEnergy != nil {
+		m.ATotalActRetEnergy = types.Float64Value(*got.ATotalActRetEnergy)
+	}
+	if got.BTotalActEnergy != nil {
+		m.BTotalActEnergy = types.Float64Value(*got.BTotalActEnergy)
+	}
+	if got.BTotalActRetEnergy != nil {
+		m.BTotalActRetEnergy = types.Float64Value(*got.BTotalActRetEnergy)
+	}
+	if got.CTotalActEnergy != nil {
+		m.CTotalActEnergy = types.Float64Value(*got.CTotalActEnergy)
+	}
+	if got.CTotalActRetEnergy != nil {
+		m.CTotalActRetEnergy = types.Float64Value(*got.CTotalActRetEnergy)
+	}
+	if got.TotalAct != nil {
+		m.TotalAct = types.Float64Value(*got.TotalAct)
+	}
+	if got.TotalActRet != nil {
+		m.TotalActRet = types.Float64Value(*got.TotalActRet)
+	}
+	if got.Errors != nil {
+		l, d := types.ListValueFrom(ctx, types.StringType, got.Errors)
+		diags.Append(d...)
+		m.Errors = l
 	}
 }
 
@@ -107,42 +156,14 @@ func (r *emdataConfigResource) Read(ctx context.Context, req resource.ReadReques
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.EMDataGetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.ATotalActEnergy != nil {
-		state.ATotalActEnergy = types.Float64Value(*got.ATotalActEnergy)
-	}
-	if got.ATotalActRetEnergy != nil {
-		state.ATotalActRetEnergy = types.Float64Value(*got.ATotalActRetEnergy)
-	}
-	if got.BTotalActEnergy != nil {
-		state.BTotalActEnergy = types.Float64Value(*got.BTotalActEnergy)
-	}
-	if got.BTotalActRetEnergy != nil {
-		state.BTotalActRetEnergy = types.Float64Value(*got.BTotalActRetEnergy)
-	}
-	if got.CTotalActEnergy != nil {
-		state.CTotalActEnergy = types.Float64Value(*got.CTotalActEnergy)
-	}
-	if got.CTotalActRetEnergy != nil {
-		state.CTotalActRetEnergy = types.Float64Value(*got.CTotalActRetEnergy)
-	}
-	if got.TotalAct != nil {
-		state.TotalAct = types.Float64Value(*got.TotalAct)
-	}
-	if got.TotalActRet != nil {
-		state.TotalActRet = types.Float64Value(*got.TotalActRet)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *emdataConfigResource) apply(plan emdataConfigResourceModel, diags *diag.Diagnostics) {
+func (r *emdataConfigResource) apply(ctx context.Context, plan emdataConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.EMDataConfig
 	cfg.ID = int(plan.ID.ValueInt64())
 	if !plan.ATotalActEnergy.IsNull() && !plan.ATotalActEnergy.IsUnknown() {
@@ -177,6 +198,11 @@ func (r *emdataConfigResource) apply(plan emdataConfigResourceModel, diags *diag
 		v := plan.TotalActRet.ValueFloat64()
 		cfg.TotalActRet = &v
 	}
+	if !plan.Errors.IsNull() && !plan.Errors.IsUnknown() {
+		var v []string
+		diags.Append(plan.Errors.ElementsAs(ctx, &v, false)...)
+		cfg.Errors = v
+	}
 	client := resty.New()
 	defer client.Close()
 	client.SetBaseURL("http://" + plan.IP.ValueString())
@@ -191,7 +217,11 @@ func (r *emdataConfigResource) Create(ctx context.Context, req resource.CreateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -204,7 +234,11 @@ func (r *emdataConfigResource) Update(ctx context.Context, req resource.UpdateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/eth_config_resource_gen.go
+++ b/internal/provider/eth_config_resource_gen.go
@@ -100,48 +100,55 @@ func (r *ethConfigResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 	}
 }
 
+func (r *ethConfigResource) get(ctx context.Context, m *ethConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.EthGetConfigRequest{}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Enable != nil {
+		m.Enable = types.BoolValue(*got.Enable)
+	}
+	if got.ServerMode != nil {
+		m.ServerMode = types.BoolValue(*got.ServerMode)
+	}
+	if got.Ipv4mode != nil {
+		m.Ipv4mode = types.StringValue(*got.Ipv4mode)
+	}
+	if got.Netmask != nil {
+		m.Netmask = types.StringValue(*got.Netmask)
+	}
+	if got.Gw != nil {
+		m.Gw = types.StringValue(*got.Gw)
+	}
+	if got.Nameserver != nil {
+		m.Nameserver = types.StringValue(*got.Nameserver)
+	}
+	if got.DhcpStart != nil {
+		m.DhcpStart = types.StringValue(*got.DhcpStart)
+	}
+	if got.DhcpEnd != nil {
+		m.DhcpEnd = types.StringValue(*got.DhcpEnd)
+	}
+}
+
 func (r *ethConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state ethConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.EthGetConfigRequest{}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Enable != nil {
-		state.Enable = types.BoolValue(*got.Enable)
-	}
-	if got.ServerMode != nil {
-		state.ServerMode = types.BoolValue(*got.ServerMode)
-	}
-	if got.Ipv4mode != nil {
-		state.Ipv4mode = types.StringValue(*got.Ipv4mode)
-	}
-	if got.Netmask != nil {
-		state.Netmask = types.StringValue(*got.Netmask)
-	}
-	if got.Gw != nil {
-		state.Gw = types.StringValue(*got.Gw)
-	}
-	if got.Nameserver != nil {
-		state.Nameserver = types.StringValue(*got.Nameserver)
-	}
-	if got.DhcpStart != nil {
-		state.DhcpStart = types.StringValue(*got.DhcpStart)
-	}
-	if got.DhcpEnd != nil {
-		state.DhcpEnd = types.StringValue(*got.DhcpEnd)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *ethConfigResource) apply(plan ethConfigResourceModel, diags *diag.Diagnostics) {
+func (r *ethConfigResource) apply(ctx context.Context, plan ethConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.EthConfig
 	if !plan.Enable.IsNull() && !plan.Enable.IsUnknown() {
 		v := plan.Enable.ValueBool()
@@ -189,7 +196,11 @@ func (r *ethConfigResource) Create(ctx context.Context, req resource.CreateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -202,7 +213,11 @@ func (r *ethConfigResource) Update(ctx context.Context, req resource.UpdateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/flood_config_resource_gen.go
+++ b/internal/provider/flood_config_resource_gen.go
@@ -67,33 +67,40 @@ func (r *floodConfigResource) Schema(_ context.Context, _ resource.SchemaRequest
 	}
 }
 
+func (r *floodConfigResource) get(ctx context.Context, m *floodConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.FloodGetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Name != nil {
+		m.Name = types.StringValue(*got.Name)
+	}
+	if got.AlarmMode != nil {
+		m.AlarmMode = types.StringValue(*got.AlarmMode)
+	}
+	if got.ReportHoldoff != nil {
+		m.ReportHoldoff = types.Float64Value(*got.ReportHoldoff)
+	}
+}
+
 func (r *floodConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state floodConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.FloodGetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Name != nil {
-		state.Name = types.StringValue(*got.Name)
-	}
-	if got.AlarmMode != nil {
-		state.AlarmMode = types.StringValue(*got.AlarmMode)
-	}
-	if got.ReportHoldoff != nil {
-		state.ReportHoldoff = types.Float64Value(*got.ReportHoldoff)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *floodConfigResource) apply(plan floodConfigResourceModel, diags *diag.Diagnostics) {
+func (r *floodConfigResource) apply(ctx context.Context, plan floodConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.FloodConfig
 	cfg.ID = int(plan.ID.ValueInt64())
 	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
@@ -122,7 +129,11 @@ func (r *floodConfigResource) Create(ctx context.Context, req resource.CreateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -135,7 +146,11 @@ func (r *floodConfigResource) Update(ctx context.Context, req resource.UpdateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/gen/main.go
+++ b/internal/provider/gen/main.go
@@ -87,17 +87,18 @@ func (n *tnode) child(seg string) *tnode {
 
 func (n *tnode) leaf() bool { return n.field != nil }
 
-// buildTree builds the config tree from a component's fields, keeping only scalar
-// leaves (string/number/integer/boolean) and dropping the identity keys, arrays
-// and opaque objects. Intermediate objects appear via the dotted key segments.
+// buildTree builds the config tree from a component's fields, keeping the
+// representable leaves (scalars and arrays of scalars) and dropping the identity
+// keys and opaque objects. Intermediate objects appear via the dotted key
+// segments.
 func buildTree(c *gen.Component) *tnode {
 	root := newTnode("")
 	for _, f := range c.Fields {
 		if f.Key == "id" || f.Key == "ip" {
 			continue
 		}
-		if !scalar(f.Type) {
-			continue // array / object-leaf / unknown — not representable yet
+		if !representable(f) {
+			continue // opaque object / typeless array — not representable
 		}
 		cur := root
 		segs := strings.Split(f.Key, ".")
@@ -117,6 +118,49 @@ func scalar(t string) bool {
 		return true
 	}
 	return false
+}
+
+// representable reports whether a leaf field can be exposed as a Terraform
+// attribute: a scalar, or an array whose element type the docs name.
+func representable(f *gen.Field) bool {
+	if scalar(f.Type) {
+		return true
+	}
+	_, _, ok := arrayInfo(f.Elem)
+	return f.Type == "array" && ok
+}
+
+// arrayInfo maps an array element base type to its Terraform element type and the
+// library's Go slice type. ok is false for arrays whose element type the docs
+// don't specify (the library leaves those as json.RawMessage; we skip them).
+func arrayInfo(elem string) (tfElemType, goSlice string, ok bool) {
+	switch elem {
+	case "number":
+		return "types.Float64Type", "[]float64", true
+	case "integer":
+		return "types.Int64Type", "[]int", true
+	case "string":
+		return "types.StringType", "[]string", true
+	case "boolean":
+		return "types.BoolType", "[]bool", true
+	}
+	return "", "", false
+}
+
+// readOnly reports whether a field is documented as read-only (its description
+// starts with "Read-only"). Such fields are Computed-only: surfaced in state but
+// never sent to SetConfig. Fields that merely mention read-only mid-sentence with
+// caveats (e.g. enhanced_security) stay settable.
+func readOnly(f *gen.Field) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(f.Description)), "read-only")
+}
+
+// modelFieldType is the Terraform model field type for a leaf.
+func modelFieldType(f *gen.Field) string {
+	if f.Type == "array" {
+		return "types.List"
+	}
+	return info(f.Type).Model
 }
 
 // --- emission ----------------------------------------------------------------
@@ -234,7 +278,7 @@ func emitModelFields(b *strings.Builder, lower string, path []string, n *tnode) 
 		c := n.children[seg]
 		g := gen.GoName(seg)
 		if c.leaf() {
-			fmt.Fprintf(b, "\t%s %s `tfsdk:%q`\n", g, info(c.field.Type).Model, attrName(seg))
+			fmt.Fprintf(b, "\t%s %s `tfsdk:%q`\n", g, modelFieldType(c.field), attrName(seg))
 			continue
 		}
 		sub := childPath(path, seg)
@@ -264,9 +308,26 @@ func emitSchemaAttrs(b *strings.Builder, n *tnode, imp *imports) {
 			continue
 		}
 		f := c.field
+		ro := readOnly(f)
+
+		// availability is the Optional/Computed line: settable fields are both;
+		// read-only fields are Computed-only so plans never try to set them.
+		availability := "Optional: true,\nComputed: true,\n"
+		if ro {
+			availability = "Computed: true,\n"
+		}
+
+		if f.Type == "array" {
+			tfElem, _, _ := arrayInfo(f.Elem)
+			imp.add("github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier")
+			fmt.Fprintf(b, "%q: schema.ListAttribute{\nElementType: %s,\n%sMarkdownDescription: %q,\n", attrName(seg), tfElem, availability, f.Description)
+			b.WriteString("PlanModifiers: []planmodifier.List{listplanmodifier.UseStateForUnknown()},\n},\n")
+			continue
+		}
+
 		ti := info(f.Type)
-		fmt.Fprintf(b, "%q: %s{\nOptional: true,\nComputed: true,\nMarkdownDescription: %q,\n", attrName(seg), ti.Attr, f.Description)
-		if f.Type == "string" && len(f.Enum) > 0 {
+		fmt.Fprintf(b, "%q: %s{\n%sMarkdownDescription: %q,\n", attrName(seg), ti.Attr, availability, f.Description)
+		if !ro && f.Type == "string" && len(f.Enum) > 0 {
 			imp.add("github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator",
 				"github.com/hashicorp/terraform-plugin-framework/schema/validator")
 			quoted := make([]string, len(f.Enum))
@@ -281,16 +342,25 @@ func emitSchemaAttrs(b *strings.Builder, n *tnode, imp *imports) {
 }
 
 func emitRead(b *strings.Builder, typeName, lower string, c *gen.Component, root *tnode) {
-	fmt.Fprintf(b, "func (r *%s) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {\n\tvar state %s\n", typeName, modelType(lower, nil))
-	b.WriteString("\tresp.Diagnostics.Append(req.State.Get(ctx, &state)...)\n\tif resp.Diagnostics.HasError() {\n\t\treturn\n\t}\n")
-	b.WriteString("\tclient := resty.New()\n\tdefer client.Close()\n\tclient.SetBaseURL(\"http://\" + state.IP.ValueString())\n")
+	model := modelType(lower, nil)
+
+	// get reads the live config into m. It is shared by Read and by Create/Update,
+	// which read back after applying so Computed values (read-only fields, server
+	// defaults) are known in state.
+	fmt.Fprintf(b, "func (r *%s) get(ctx context.Context, m *%s, diags *diag.Diagnostics) {\n", typeName, model)
+	b.WriteString("\tclient := resty.New()\n\tdefer client.Close()\n\tclient.SetBaseURL(\"http://\" + m.IP.ValueString())\n")
 	if c.Keyed {
-		fmt.Fprintf(b, "\tgot, _, err := (&components.%sGetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)\n", c.Prefix())
+		fmt.Fprintf(b, "\tgot, _, err := (&components.%sGetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)\n", c.Prefix())
 	} else {
 		fmt.Fprintf(b, "\tgot, _, err := (&components.%sGetConfigRequest{}).Do(client)\n", c.Prefix())
 	}
-	b.WriteString("\tif err != nil {\n\t\tresp.Diagnostics.AddError(\"Failed to read config\", err.Error())\n\t\treturn\n\t}\n")
-	emitReadNode(b, lower, "got", "state", nil, root)
+	b.WriteString("\tif err != nil {\n\t\tdiags.AddError(\"Failed to read config\", err.Error())\n\t\treturn\n\t}\n")
+	emitReadNode(b, lower, "got", "m", nil, root)
+	b.WriteString("}\n\n")
+
+	fmt.Fprintf(b, "func (r *%s) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {\n\tvar state %s\n", typeName, model)
+	b.WriteString("\tresp.Diagnostics.Append(req.State.Get(ctx, &state)...)\n\tif resp.Diagnostics.HasError() {\n\t\treturn\n\t}\n")
+	b.WriteString("\tr.get(ctx, &state, &resp.Diagnostics)\n\tif resp.Diagnostics.HasError() {\n\t\treturn\n\t}\n")
 	b.WriteString("\tresp.Diagnostics.Append(resp.State.Set(ctx, &state)...)\n}\n\n")
 }
 
@@ -299,7 +369,13 @@ func emitReadNode(b *strings.Builder, lower, got, state string, path []string, n
 		c := n.children[seg]
 		g := gen.GoName(seg)
 		if c.leaf() {
-			fmt.Fprintf(b, "\tif %s.%s != nil {\n\t\t%s.%s = %s\n\t}\n", got, g, state, g, readConv(c.field.Type, got+"."+g))
+			f := c.field
+			if f.Type == "array" {
+				tfElem, _, _ := arrayInfo(f.Elem)
+				fmt.Fprintf(b, "\tif %s.%s != nil {\n\t\tl, d := types.ListValueFrom(ctx, %s, %s.%s)\n\t\tdiags.Append(d...)\n\t\t%s.%s = l\n\t}\n", got, g, tfElem, got, g, state, g)
+			} else {
+				fmt.Fprintf(b, "\tif %s.%s != nil {\n\t\t%s.%s = %s\n\t}\n", got, g, state, g, readConv(f.Type, got+"."+g))
+			}
 			continue
 		}
 		sub := childPath(path, seg)
@@ -312,7 +388,9 @@ func emitReadNode(b *strings.Builder, lower, got, state string, path []string, n
 }
 
 func emitWrite(b *strings.Builder, typeName, lower string, c *gen.Component, root *tnode) {
-	fmt.Fprintf(b, "func (r *%s) apply(plan %s, diags *diag.Diagnostics) {\n\tvar cfg components.%sConfig\n", typeName, modelType(lower, nil), c.Prefix())
+	model := modelType(lower, nil)
+
+	fmt.Fprintf(b, "func (r *%s) apply(ctx context.Context, plan %s, diags *diag.Diagnostics) {\n\tvar cfg components.%sConfig\n", typeName, model, c.Prefix())
 	if c.Keyed {
 		b.WriteString("\tcfg.ID = int(plan.ID.ValueInt64())\n")
 	}
@@ -326,9 +404,11 @@ func emitWrite(b *strings.Builder, typeName, lower string, c *gen.Component, roo
 	b.WriteString("\t\tdiags.AddError(\"Failed to set config\", err.Error())\n\t}\n}\n\n")
 
 	for _, op := range []string{"Create", "Update"} {
-		fmt.Fprintf(b, "func (r *%s) %s(ctx context.Context, req resource.%sRequest, resp *resource.%sResponse) {\n\tvar plan %s\n", typeName, op, op, op, modelType(lower, nil))
+		fmt.Fprintf(b, "func (r *%s) %s(ctx context.Context, req resource.%sRequest, resp *resource.%sResponse) {\n\tvar plan %s\n", typeName, op, op, op, model)
 		b.WriteString("\tresp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)\n\tif resp.Diagnostics.HasError() {\n\t\treturn\n\t}\n")
-		b.WriteString("\tr.apply(plan, &resp.Diagnostics)\n\tif resp.Diagnostics.HasError() {\n\t\treturn\n\t}\n")
+		b.WriteString("\tr.apply(ctx, plan, &resp.Diagnostics)\n\tif resp.Diagnostics.HasError() {\n\t\treturn\n\t}\n")
+		// Read back so Computed values (read-only fields, server defaults) are known.
+		b.WriteString("\tr.get(ctx, &plan, &resp.Diagnostics)\n\tif resp.Diagnostics.HasError() {\n\t\treturn\n\t}\n")
 		b.WriteString("\tresp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)\n}\n\n")
 	}
 }
@@ -338,7 +418,16 @@ func emitWriteNode(b *strings.Builder, prefix, cfg, plan string, path []string, 
 		c := n.children[seg]
 		g := gen.GoName(seg)
 		if c.leaf() {
-			fmt.Fprintf(b, "\tif !%s.%s.IsNull() && !%s.%s.IsUnknown() {\n\t\t%s\n\t}\n", plan, g, plan, g, setStmt(c.field.Type, cfg+"."+g, plan+"."+g))
+			f := c.field
+			if readOnly(f) {
+				continue // read-only: surfaced in state, never sent to SetConfig
+			}
+			if f.Type == "array" {
+				_, goSlice, _ := arrayInfo(f.Elem)
+				fmt.Fprintf(b, "\tif !%s.%s.IsNull() && !%s.%s.IsUnknown() {\n\t\tvar v %s\n\t\tdiags.Append(%s.%s.ElementsAs(ctx, &v, false)...)\n\t\t%s.%s = v\n\t}\n", plan, g, plan, g, goSlice, plan, g, cfg, g)
+				continue
+			}
+			fmt.Fprintf(b, "\tif !%s.%s.IsNull() && !%s.%s.IsUnknown() {\n\t\t%s\n\t}\n", plan, g, plan, g, setStmt(f.Type, cfg+"."+g, plan+"."+g))
 			continue
 		}
 		sub := childPath(path, seg)

--- a/internal/provider/humidity_config_resource_gen.go
+++ b/internal/provider/humidity_config_resource_gen.go
@@ -67,33 +67,40 @@ func (r *humidityConfigResource) Schema(_ context.Context, _ resource.SchemaRequ
 	}
 }
 
+func (r *humidityConfigResource) get(ctx context.Context, m *humidityConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.HumidityGetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Name != nil {
+		m.Name = types.StringValue(*got.Name)
+	}
+	if got.ReportThr != nil {
+		m.ReportThr = types.Float64Value(*got.ReportThr)
+	}
+	if got.Offset != nil {
+		m.Offset = types.Float64Value(*got.Offset)
+	}
+}
+
 func (r *humidityConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state humidityConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.HumidityGetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Name != nil {
-		state.Name = types.StringValue(*got.Name)
-	}
-	if got.ReportThr != nil {
-		state.ReportThr = types.Float64Value(*got.ReportThr)
-	}
-	if got.Offset != nil {
-		state.Offset = types.Float64Value(*got.Offset)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *humidityConfigResource) apply(plan humidityConfigResourceModel, diags *diag.Diagnostics) {
+func (r *humidityConfigResource) apply(ctx context.Context, plan humidityConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.HumidityConfig
 	cfg.ID = int(plan.ID.ValueInt64())
 	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
@@ -122,7 +129,11 @@ func (r *humidityConfigResource) Create(ctx context.Context, req resource.Create
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -135,7 +146,11 @@ func (r *humidityConfigResource) Update(ctx context.Context, req resource.Update
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/illuminance_config_resource_gen.go
+++ b/internal/provider/illuminance_config_resource_gen.go
@@ -67,33 +67,40 @@ func (r *illuminanceConfigResource) Schema(_ context.Context, _ resource.SchemaR
 	}
 }
 
+func (r *illuminanceConfigResource) get(ctx context.Context, m *illuminanceConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.IlluminanceGetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Name != nil {
+		m.Name = types.StringValue(*got.Name)
+	}
+	if got.DarkThr != nil {
+		m.DarkThr = types.Float64Value(*got.DarkThr)
+	}
+	if got.BrightThr != nil {
+		m.BrightThr = types.Float64Value(*got.BrightThr)
+	}
+}
+
 func (r *illuminanceConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state illuminanceConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.IlluminanceGetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Name != nil {
-		state.Name = types.StringValue(*got.Name)
-	}
-	if got.DarkThr != nil {
-		state.DarkThr = types.Float64Value(*got.DarkThr)
-	}
-	if got.BrightThr != nil {
-		state.BrightThr = types.Float64Value(*got.BrightThr)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *illuminanceConfigResource) apply(plan illuminanceConfigResourceModel, diags *diag.Diagnostics) {
+func (r *illuminanceConfigResource) apply(ctx context.Context, plan illuminanceConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.IlluminanceConfig
 	cfg.ID = int(plan.ID.ValueInt64())
 	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
@@ -122,7 +129,11 @@ func (r *illuminanceConfigResource) Create(ctx context.Context, req resource.Cre
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -135,7 +146,11 @@ func (r *illuminanceConfigResource) Update(ctx context.Context, req resource.Upd
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/input_config_resource_gen.go
+++ b/internal/provider/input_config_resource_gen.go
@@ -193,87 +193,94 @@ func (r *inputConfigResource) Schema(_ context.Context, _ resource.SchemaRequest
 	}
 }
 
+func (r *inputConfigResource) get(ctx context.Context, m *inputConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.InputGetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Name != nil {
+		m.Name = types.StringValue(*got.Name)
+	}
+	if got.Type != nil {
+		m.Type = types.StringValue(*got.Type)
+	}
+	if got.Enable != nil {
+		m.Enable = types.BoolValue(*got.Enable)
+	}
+	if got.Invert != nil {
+		m.Invert = types.BoolValue(*got.Invert)
+	}
+	if got.FactoryReset != nil {
+		m.FactoryReset = types.BoolValue(*got.FactoryReset)
+	}
+	if got.ReportThr != nil {
+		m.ReportThr = types.Float64Value(*got.ReportThr)
+	}
+	if got.Range != nil {
+		m.Range = types.Float64Value(*got.Range)
+	}
+	if got.Xpercent != nil {
+		if m.Xpercent == nil {
+			m.Xpercent = &inputConfigXpercentModel{}
+		}
+		if got.Xpercent.Expr != nil {
+			m.Xpercent.Expr = types.StringValue(*got.Xpercent.Expr)
+		}
+		if got.Xpercent.Unit != nil {
+			m.Xpercent.Unit = types.StringValue(*got.Xpercent.Unit)
+		}
+	}
+	if got.CountRepThr != nil {
+		m.CountRepThr = types.Float64Value(*got.CountRepThr)
+	}
+	if got.FreqWindow != nil {
+		m.FreqWindow = types.Float64Value(*got.FreqWindow)
+	}
+	if got.FreqRepThr != nil {
+		m.FreqRepThr = types.Float64Value(*got.FreqRepThr)
+	}
+	if got.Xcounts != nil {
+		if m.Xcounts == nil {
+			m.Xcounts = &inputConfigXcountsModel{}
+		}
+		if got.Xcounts.Expr != nil {
+			m.Xcounts.Expr = types.StringValue(*got.Xcounts.Expr)
+		}
+		if got.Xcounts.Unit != nil {
+			m.Xcounts.Unit = types.StringValue(*got.Xcounts.Unit)
+		}
+	}
+	if got.Xfreq != nil {
+		if m.Xfreq == nil {
+			m.Xfreq = &inputConfigXfreqModel{}
+		}
+		if got.Xfreq.Expr != nil {
+			m.Xfreq.Expr = types.StringValue(*got.Xfreq.Expr)
+		}
+		if got.Xfreq.Unit != nil {
+			m.Xfreq.Unit = types.StringValue(*got.Xfreq.Unit)
+		}
+	}
+}
+
 func (r *inputConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state inputConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.InputGetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Name != nil {
-		state.Name = types.StringValue(*got.Name)
-	}
-	if got.Type != nil {
-		state.Type = types.StringValue(*got.Type)
-	}
-	if got.Enable != nil {
-		state.Enable = types.BoolValue(*got.Enable)
-	}
-	if got.Invert != nil {
-		state.Invert = types.BoolValue(*got.Invert)
-	}
-	if got.FactoryReset != nil {
-		state.FactoryReset = types.BoolValue(*got.FactoryReset)
-	}
-	if got.ReportThr != nil {
-		state.ReportThr = types.Float64Value(*got.ReportThr)
-	}
-	if got.Range != nil {
-		state.Range = types.Float64Value(*got.Range)
-	}
-	if got.Xpercent != nil {
-		if state.Xpercent == nil {
-			state.Xpercent = &inputConfigXpercentModel{}
-		}
-		if got.Xpercent.Expr != nil {
-			state.Xpercent.Expr = types.StringValue(*got.Xpercent.Expr)
-		}
-		if got.Xpercent.Unit != nil {
-			state.Xpercent.Unit = types.StringValue(*got.Xpercent.Unit)
-		}
-	}
-	if got.CountRepThr != nil {
-		state.CountRepThr = types.Float64Value(*got.CountRepThr)
-	}
-	if got.FreqWindow != nil {
-		state.FreqWindow = types.Float64Value(*got.FreqWindow)
-	}
-	if got.FreqRepThr != nil {
-		state.FreqRepThr = types.Float64Value(*got.FreqRepThr)
-	}
-	if got.Xcounts != nil {
-		if state.Xcounts == nil {
-			state.Xcounts = &inputConfigXcountsModel{}
-		}
-		if got.Xcounts.Expr != nil {
-			state.Xcounts.Expr = types.StringValue(*got.Xcounts.Expr)
-		}
-		if got.Xcounts.Unit != nil {
-			state.Xcounts.Unit = types.StringValue(*got.Xcounts.Unit)
-		}
-	}
-	if got.Xfreq != nil {
-		if state.Xfreq == nil {
-			state.Xfreq = &inputConfigXfreqModel{}
-		}
-		if got.Xfreq.Expr != nil {
-			state.Xfreq.Expr = types.StringValue(*got.Xfreq.Expr)
-		}
-		if got.Xfreq.Unit != nil {
-			state.Xfreq.Unit = types.StringValue(*got.Xfreq.Unit)
-		}
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *inputConfigResource) apply(plan inputConfigResourceModel, diags *diag.Diagnostics) {
+func (r *inputConfigResource) apply(ctx context.Context, plan inputConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.InputConfig
 	cfg.ID = int(plan.ID.ValueInt64())
 	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
@@ -363,7 +370,11 @@ func (r *inputConfigResource) Create(ctx context.Context, req resource.CreateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -376,7 +387,11 @@ func (r *inputConfigResource) Update(ctx context.Context, req resource.UpdateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/light_config_resource_gen.go
+++ b/internal/provider/light_config_resource_gen.go
@@ -250,110 +250,117 @@ func (r *lightConfigResource) Schema(_ context.Context, _ resource.SchemaRequest
 	}
 }
 
+func (r *lightConfigResource) get(ctx context.Context, m *lightConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.LightGetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Name != nil {
+		m.Name = types.StringValue(*got.Name)
+	}
+	if got.InMode != nil {
+		m.InMode = types.StringValue(*got.InMode)
+	}
+	if got.OpMode != nil {
+		m.OpMode = types.Float64Value(*got.OpMode)
+	}
+	if got.InitialState != nil {
+		m.InitialState = types.StringValue(*got.InitialState)
+	}
+	if got.AutoOn != nil {
+		m.AutoOn = types.BoolValue(*got.AutoOn)
+	}
+	if got.AutoOnDelay != nil {
+		m.AutoOnDelay = types.Float64Value(*got.AutoOnDelay)
+	}
+	if got.AutoOff != nil {
+		m.AutoOff = types.BoolValue(*got.AutoOff)
+	}
+	if got.AutoOffDelay != nil {
+		m.AutoOffDelay = types.Float64Value(*got.AutoOffDelay)
+	}
+	if got.TransitionDuration != nil {
+		m.TransitionDuration = types.Float64Value(*got.TransitionDuration)
+	}
+	if got.Gamma != nil {
+		m.Gamma = types.Float64Value(*got.Gamma)
+	}
+	if got.MinBrightnessOnToggle != nil {
+		m.MinBrightnessOnToggle = types.Float64Value(*got.MinBrightnessOnToggle)
+	}
+	if got.NightMode != nil {
+		if m.NightMode == nil {
+			m.NightMode = &lightConfigNightModeModel{}
+		}
+		if got.NightMode.Enable != nil {
+			m.NightMode.Enable = types.BoolValue(*got.NightMode.Enable)
+		}
+		if got.NightMode.Brightness != nil {
+			m.NightMode.Brightness = types.Float64Value(*got.NightMode.Brightness)
+		}
+	}
+	if got.ButtonFadeRate != nil {
+		m.ButtonFadeRate = types.Float64Value(*got.ButtonFadeRate)
+	}
+	if got.ButtonPresets != nil {
+		if m.ButtonPresets == nil {
+			m.ButtonPresets = &lightConfigButtonPresetsModel{}
+		}
+		if got.ButtonPresets.ButtonDoublepush != nil {
+			if m.ButtonPresets.ButtonDoublepush == nil {
+				m.ButtonPresets.ButtonDoublepush = &lightConfigButtonPresetsButtonDoublepushModel{}
+			}
+			if got.ButtonPresets.ButtonDoublepush.Brightness != nil {
+				m.ButtonPresets.ButtonDoublepush.Brightness = types.Float64Value(*got.ButtonPresets.ButtonDoublepush.Brightness)
+			}
+		}
+	}
+	if got.PowerLimit != nil {
+		m.PowerLimit = types.Float64Value(*got.PowerLimit)
+	}
+	if got.VoltageLimit != nil {
+		m.VoltageLimit = types.Float64Value(*got.VoltageLimit)
+	}
+	if got.UndervoltageLimit != nil {
+		m.UndervoltageLimit = types.Float64Value(*got.UndervoltageLimit)
+	}
+	if got.CurrentLimit != nil {
+		m.CurrentLimit = types.Float64Value(*got.CurrentLimit)
+	}
+	if got.Warmup != nil {
+		if m.Warmup == nil {
+			m.Warmup = &lightConfigWarmupModel{}
+		}
+		if got.Warmup.Enable != nil {
+			m.Warmup.Enable = types.BoolValue(*got.Warmup.Enable)
+		}
+		if got.Warmup.Brightness != nil {
+			m.Warmup.Brightness = types.Float64Value(*got.Warmup.Brightness)
+		}
+		if got.Warmup.TimeMs != nil {
+			m.Warmup.TimeMs = types.Float64Value(*got.Warmup.TimeMs)
+		}
+	}
+}
+
 func (r *lightConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state lightConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.LightGetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Name != nil {
-		state.Name = types.StringValue(*got.Name)
-	}
-	if got.InMode != nil {
-		state.InMode = types.StringValue(*got.InMode)
-	}
-	if got.OpMode != nil {
-		state.OpMode = types.Float64Value(*got.OpMode)
-	}
-	if got.InitialState != nil {
-		state.InitialState = types.StringValue(*got.InitialState)
-	}
-	if got.AutoOn != nil {
-		state.AutoOn = types.BoolValue(*got.AutoOn)
-	}
-	if got.AutoOnDelay != nil {
-		state.AutoOnDelay = types.Float64Value(*got.AutoOnDelay)
-	}
-	if got.AutoOff != nil {
-		state.AutoOff = types.BoolValue(*got.AutoOff)
-	}
-	if got.AutoOffDelay != nil {
-		state.AutoOffDelay = types.Float64Value(*got.AutoOffDelay)
-	}
-	if got.TransitionDuration != nil {
-		state.TransitionDuration = types.Float64Value(*got.TransitionDuration)
-	}
-	if got.Gamma != nil {
-		state.Gamma = types.Float64Value(*got.Gamma)
-	}
-	if got.MinBrightnessOnToggle != nil {
-		state.MinBrightnessOnToggle = types.Float64Value(*got.MinBrightnessOnToggle)
-	}
-	if got.NightMode != nil {
-		if state.NightMode == nil {
-			state.NightMode = &lightConfigNightModeModel{}
-		}
-		if got.NightMode.Enable != nil {
-			state.NightMode.Enable = types.BoolValue(*got.NightMode.Enable)
-		}
-		if got.NightMode.Brightness != nil {
-			state.NightMode.Brightness = types.Float64Value(*got.NightMode.Brightness)
-		}
-	}
-	if got.ButtonFadeRate != nil {
-		state.ButtonFadeRate = types.Float64Value(*got.ButtonFadeRate)
-	}
-	if got.ButtonPresets != nil {
-		if state.ButtonPresets == nil {
-			state.ButtonPresets = &lightConfigButtonPresetsModel{}
-		}
-		if got.ButtonPresets.ButtonDoublepush != nil {
-			if state.ButtonPresets.ButtonDoublepush == nil {
-				state.ButtonPresets.ButtonDoublepush = &lightConfigButtonPresetsButtonDoublepushModel{}
-			}
-			if got.ButtonPresets.ButtonDoublepush.Brightness != nil {
-				state.ButtonPresets.ButtonDoublepush.Brightness = types.Float64Value(*got.ButtonPresets.ButtonDoublepush.Brightness)
-			}
-		}
-	}
-	if got.PowerLimit != nil {
-		state.PowerLimit = types.Float64Value(*got.PowerLimit)
-	}
-	if got.VoltageLimit != nil {
-		state.VoltageLimit = types.Float64Value(*got.VoltageLimit)
-	}
-	if got.UndervoltageLimit != nil {
-		state.UndervoltageLimit = types.Float64Value(*got.UndervoltageLimit)
-	}
-	if got.CurrentLimit != nil {
-		state.CurrentLimit = types.Float64Value(*got.CurrentLimit)
-	}
-	if got.Warmup != nil {
-		if state.Warmup == nil {
-			state.Warmup = &lightConfigWarmupModel{}
-		}
-		if got.Warmup.Enable != nil {
-			state.Warmup.Enable = types.BoolValue(*got.Warmup.Enable)
-		}
-		if got.Warmup.Brightness != nil {
-			state.Warmup.Brightness = types.Float64Value(*got.Warmup.Brightness)
-		}
-		if got.Warmup.TimeMs != nil {
-			state.Warmup.TimeMs = types.Float64Value(*got.Warmup.TimeMs)
-		}
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *lightConfigResource) apply(plan lightConfigResourceModel, diags *diag.Diagnostics) {
+func (r *lightConfigResource) apply(ctx context.Context, plan lightConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.LightConfig
 	cfg.ID = int(plan.ID.ValueInt64())
 	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
@@ -470,7 +477,11 @@ func (r *lightConfigResource) Create(ctx context.Context, req resource.CreateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -483,7 +494,11 @@ func (r *lightConfigResource) Update(ctx context.Context, req resource.UpdateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/matter_config_resource_gen.go
+++ b/internal/provider/matter_config_resource_gen.go
@@ -47,27 +47,34 @@ func (r *matterConfigResource) Schema(_ context.Context, _ resource.SchemaReques
 	}
 }
 
+func (r *matterConfigResource) get(ctx context.Context, m *matterConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.MatterGetConfigRequest{}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Enable != nil {
+		m.Enable = types.BoolValue(*got.Enable)
+	}
+}
+
 func (r *matterConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state matterConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.MatterGetConfigRequest{}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Enable != nil {
-		state.Enable = types.BoolValue(*got.Enable)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *matterConfigResource) apply(plan matterConfigResourceModel, diags *diag.Diagnostics) {
+func (r *matterConfigResource) apply(ctx context.Context, plan matterConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.MatterConfig
 	if !plan.Enable.IsNull() && !plan.Enable.IsUnknown() {
 		v := plan.Enable.ValueBool()
@@ -87,7 +94,11 @@ func (r *matterConfigResource) Create(ctx context.Context, req resource.CreateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -100,7 +111,11 @@ func (r *matterConfigResource) Update(ctx context.Context, req resource.UpdateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/modbus_config_resource_gen.go
+++ b/internal/provider/modbus_config_resource_gen.go
@@ -47,27 +47,34 @@ func (r *modbusConfigResource) Schema(_ context.Context, _ resource.SchemaReques
 	}
 }
 
+func (r *modbusConfigResource) get(ctx context.Context, m *modbusConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.ModbusGetConfigRequest{}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Enable != nil {
+		m.Enable = types.BoolValue(*got.Enable)
+	}
+}
+
 func (r *modbusConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state modbusConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.ModbusGetConfigRequest{}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Enable != nil {
-		state.Enable = types.BoolValue(*got.Enable)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *modbusConfigResource) apply(plan modbusConfigResourceModel, diags *diag.Diagnostics) {
+func (r *modbusConfigResource) apply(ctx context.Context, plan modbusConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.ModbusConfig
 	if !plan.Enable.IsNull() && !plan.Enable.IsUnknown() {
 		v := plan.Enable.ValueBool()
@@ -87,7 +94,11 @@ func (r *modbusConfigResource) Create(ctx context.Context, req resource.CreateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -100,7 +111,11 @@ func (r *modbusConfigResource) Update(ctx context.Context, req resource.UpdateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/mqtt_config_resource_gen.go
+++ b/internal/provider/mqtt_config_resource_gen.go
@@ -90,45 +90,52 @@ func (r *mqttConfigResource) Schema(_ context.Context, _ resource.SchemaRequest,
 	}
 }
 
+func (r *mqttConfigResource) get(ctx context.Context, m *mqttConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.MQTTGetConfigRequest{}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Enable != nil {
+		m.Enable = types.BoolValue(*got.Enable)
+	}
+	if got.Server != nil {
+		m.Server = types.StringValue(*got.Server)
+	}
+	if got.User != nil {
+		m.User = types.StringValue(*got.User)
+	}
+	if got.RPCNtf != nil {
+		m.RPCNtf = types.BoolValue(*got.RPCNtf)
+	}
+	if got.StatusNtf != nil {
+		m.StatusNtf = types.BoolValue(*got.StatusNtf)
+	}
+	if got.UseClientCert != nil {
+		m.UseClientCert = types.BoolValue(*got.UseClientCert)
+	}
+	if got.EnableControl != nil {
+		m.EnableControl = types.BoolValue(*got.EnableControl)
+	}
+}
+
 func (r *mqttConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state mqttConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.MQTTGetConfigRequest{}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Enable != nil {
-		state.Enable = types.BoolValue(*got.Enable)
-	}
-	if got.Server != nil {
-		state.Server = types.StringValue(*got.Server)
-	}
-	if got.User != nil {
-		state.User = types.StringValue(*got.User)
-	}
-	if got.RPCNtf != nil {
-		state.RPCNtf = types.BoolValue(*got.RPCNtf)
-	}
-	if got.StatusNtf != nil {
-		state.StatusNtf = types.BoolValue(*got.StatusNtf)
-	}
-	if got.UseClientCert != nil {
-		state.UseClientCert = types.BoolValue(*got.UseClientCert)
-	}
-	if got.EnableControl != nil {
-		state.EnableControl = types.BoolValue(*got.EnableControl)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *mqttConfigResource) apply(plan mqttConfigResourceModel, diags *diag.Diagnostics) {
+func (r *mqttConfigResource) apply(ctx context.Context, plan mqttConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.MQTTConfig
 	if !plan.Enable.IsNull() && !plan.Enable.IsUnknown() {
 		v := plan.Enable.ValueBool()
@@ -172,7 +179,11 @@ func (r *mqttConfigResource) Create(ctx context.Context, req resource.CreateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -185,7 +196,11 @@ func (r *mqttConfigResource) Update(ctx context.Context, req resource.UpdateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/pill_config_resource_gen.go
+++ b/internal/provider/pill_config_resource_gen.go
@@ -68,36 +68,43 @@ func (r *pillConfigResource) Schema(_ context.Context, _ resource.SchemaRequest,
 	}
 }
 
+func (r *pillConfigResource) get(ctx context.Context, m *pillConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.PillGetConfigRequest{}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Mode != nil {
+		m.Mode = types.StringValue(*got.Mode)
+	}
+	if got.Pin0Mode != nil {
+		m.Pin0Mode = types.StringValue(*got.Pin0Mode)
+	}
+	if got.Pin1Mode != nil {
+		m.Pin1Mode = types.StringValue(*got.Pin1Mode)
+	}
+	if got.Pin2Mode != nil {
+		m.Pin2Mode = types.StringValue(*got.Pin2Mode)
+	}
+}
+
 func (r *pillConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state pillConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.PillGetConfigRequest{}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Mode != nil {
-		state.Mode = types.StringValue(*got.Mode)
-	}
-	if got.Pin0Mode != nil {
-		state.Pin0Mode = types.StringValue(*got.Pin0Mode)
-	}
-	if got.Pin1Mode != nil {
-		state.Pin1Mode = types.StringValue(*got.Pin1Mode)
-	}
-	if got.Pin2Mode != nil {
-		state.Pin2Mode = types.StringValue(*got.Pin2Mode)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *pillConfigResource) apply(plan pillConfigResourceModel, diags *diag.Diagnostics) {
+func (r *pillConfigResource) apply(ctx context.Context, plan pillConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.PillConfig
 	if !plan.Mode.IsNull() && !plan.Mode.IsUnknown() {
 		v := plan.Mode.ValueString()
@@ -129,7 +136,11 @@ func (r *pillConfigResource) Create(ctx context.Context, req resource.CreateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -142,7 +153,11 @@ func (r *pillConfigResource) Update(ctx context.Context, req resource.UpdateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/pm1_config_resource_gen.go
+++ b/internal/provider/pm1_config_resource_gen.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -28,11 +30,18 @@ func NewPM1ConfigResource() resource.Resource { return &pm1ConfigResource{} }
 
 type pm1ConfigResource struct{}
 
+type pm1ConfigAlarmsModel struct {
+	Voltage types.List `tfsdk:"voltage"`
+	Current types.List `tfsdk:"current"`
+	Power   types.List `tfsdk:"power"`
+}
+
 type pm1ConfigResourceModel struct {
-	IP      types.String `tfsdk:"ip"`
-	ID      types.Int64  `tfsdk:"id"`
-	Name    types.String `tfsdk:"name"`
-	Reverse types.Bool   `tfsdk:"reverse"`
+	IP      types.String          `tfsdk:"ip"`
+	ID      types.Int64           `tfsdk:"id"`
+	Name    types.String          `tfsdk:"name"`
+	Reverse types.Bool            `tfsdk:"reverse"`
+	Alarms  *pm1ConfigAlarmsModel `tfsdk:"alarms"`
 }
 
 func (r *pm1ConfigResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -56,7 +65,72 @@ func (r *pm1ConfigResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				MarkdownDescription: "Reverse measurement direction of active power and energy for the PM1 component. setting the reverse option requires restart",
 				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 			},
+			"alarms": schema.SingleNestedAttribute{
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
+				Attributes: map[string]schema.Attribute{
+					"voltage": schema.ListAttribute{
+						ElementType:         types.Float64Type,
+						Optional:            true,
+						Computed:            true,
+						MarkdownDescription: "['under','over'] thresholds",
+						PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+					},
+					"current": schema.ListAttribute{
+						ElementType:         types.Float64Type,
+						Optional:            true,
+						Computed:            true,
+						MarkdownDescription: "['under','over'] thresholds",
+						PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+					},
+					"power": schema.ListAttribute{
+						ElementType:         types.Float64Type,
+						Optional:            true,
+						Computed:            true,
+						MarkdownDescription: "['under','over'] thresholds",
+						PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+					},
+				},
+			},
 		},
+	}
+}
+
+func (r *pm1ConfigResource) get(ctx context.Context, m *pm1ConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.PM1GetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Name != nil {
+		m.Name = types.StringValue(*got.Name)
+	}
+	if got.Reverse != nil {
+		m.Reverse = types.BoolValue(*got.Reverse)
+	}
+	if got.Alarms != nil {
+		if m.Alarms == nil {
+			m.Alarms = &pm1ConfigAlarmsModel{}
+		}
+		if got.Alarms.Voltage != nil {
+			l, d := types.ListValueFrom(ctx, types.Float64Type, got.Alarms.Voltage)
+			diags.Append(d...)
+			m.Alarms.Voltage = l
+		}
+		if got.Alarms.Current != nil {
+			l, d := types.ListValueFrom(ctx, types.Float64Type, got.Alarms.Current)
+			diags.Append(d...)
+			m.Alarms.Current = l
+		}
+		if got.Alarms.Power != nil {
+			l, d := types.ListValueFrom(ctx, types.Float64Type, got.Alarms.Power)
+			diags.Append(d...)
+			m.Alarms.Power = l
+		}
 	}
 }
 
@@ -66,24 +140,14 @@ func (r *pm1ConfigResource) Read(ctx context.Context, req resource.ReadRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.PM1GetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Name != nil {
-		state.Name = types.StringValue(*got.Name)
-	}
-	if got.Reverse != nil {
-		state.Reverse = types.BoolValue(*got.Reverse)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *pm1ConfigResource) apply(plan pm1ConfigResourceModel, diags *diag.Diagnostics) {
+func (r *pm1ConfigResource) apply(ctx context.Context, plan pm1ConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.PM1Config
 	cfg.ID = int(plan.ID.ValueInt64())
 	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
@@ -93,6 +157,24 @@ func (r *pm1ConfigResource) apply(plan pm1ConfigResourceModel, diags *diag.Diagn
 	if !plan.Reverse.IsNull() && !plan.Reverse.IsUnknown() {
 		v := plan.Reverse.ValueBool()
 		cfg.Reverse = &v
+	}
+	if plan.Alarms != nil {
+		cfg.Alarms = &components.PM1ConfigAlarms{}
+		if !plan.Alarms.Voltage.IsNull() && !plan.Alarms.Voltage.IsUnknown() {
+			var v []float64
+			diags.Append(plan.Alarms.Voltage.ElementsAs(ctx, &v, false)...)
+			cfg.Alarms.Voltage = v
+		}
+		if !plan.Alarms.Current.IsNull() && !plan.Alarms.Current.IsUnknown() {
+			var v []float64
+			diags.Append(plan.Alarms.Current.ElementsAs(ctx, &v, false)...)
+			cfg.Alarms.Current = v
+		}
+		if !plan.Alarms.Power.IsNull() && !plan.Alarms.Power.IsUnknown() {
+			var v []float64
+			diags.Append(plan.Alarms.Power.ElementsAs(ctx, &v, false)...)
+			cfg.Alarms.Power = v
+		}
 	}
 	client := resty.New()
 	defer client.Close()
@@ -108,7 +190,11 @@ func (r *pm1ConfigResource) Create(ctx context.Context, req resource.CreateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -121,7 +207,11 @@ func (r *pm1ConfigResource) Update(ctx context.Context, req resource.UpdateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/presence_config_resource_gen.go
+++ b/internal/provider/presence_config_resource_gen.go
@@ -259,118 +259,125 @@ func (r *presenceConfigResource) Schema(_ context.Context, _ resource.SchemaRequ
 	}
 }
 
+func (r *presenceConfigResource) get(ctx context.Context, m *presenceConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.PresenceGetConfigRequest{}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Enable != nil {
+		m.Enable = types.BoolValue(*got.Enable)
+	}
+	if got.Zmin != nil {
+		m.Zmin = types.Float64Value(*got.Zmin)
+	}
+	if got.Zmax != nil {
+		m.Zmax = types.Float64Value(*got.Zmax)
+	}
+	if got.Sensor != nil {
+		if m.Sensor == nil {
+			m.Sensor = &presenceConfigSensorModel{}
+		}
+		if got.Sensor.Flipped != nil {
+			m.Sensor.Flipped = types.BoolValue(*got.Sensor.Flipped)
+		}
+		if got.Sensor.Height != nil {
+			m.Sensor.Height = types.Float64Value(*got.Sensor.Height)
+		}
+		if got.Sensor.Tilt != nil {
+			m.Sensor.Tilt = types.Float64Value(*got.Sensor.Tilt)
+		}
+		if got.Sensor.Points != nil {
+			m.Sensor.Points = types.Float64Value(*got.Sensor.Points)
+		}
+		if got.Sensor.Velocity != nil {
+			m.Sensor.Velocity = types.Float64Value(*got.Sensor.Velocity)
+		}
+		if got.Sensor.Snr != nil {
+			m.Sensor.Snr = types.Float64Value(*got.Sensor.Snr)
+		}
+		if got.Sensor.MaxVelocity != nil {
+			m.Sensor.MaxVelocity = types.Float64Value(*got.Sensor.MaxVelocity)
+		}
+		if got.Sensor.Position != nil {
+			m.Sensor.Position = types.StringValue(*got.Sensor.Position)
+		}
+		if got.Sensor.Power != nil {
+			m.Sensor.Power = types.StringValue(*got.Sensor.Power)
+		}
+		if got.Sensor.Sensitivity != nil {
+			m.Sensor.Sensitivity = types.StringValue(*got.Sensor.Sensitivity)
+		}
+		if got.Sensor.State != nil {
+			if m.Sensor.State == nil {
+				m.Sensor.State = &presenceConfigSensorStateModel{}
+			}
+			if got.Sensor.State.DetActThr != nil {
+				m.Sensor.State.DetActThr = types.Float64Value(*got.Sensor.State.DetActThr)
+			}
+			if got.Sensor.State.DetFreeThr != nil {
+				m.Sensor.State.DetFreeThr = types.Float64Value(*got.Sensor.State.DetFreeThr)
+			}
+			if got.Sensor.State.ActFreeThr != nil {
+				m.Sensor.State.ActFreeThr = types.Float64Value(*got.Sensor.State.ActFreeThr)
+			}
+			if got.Sensor.State.StatFreeThr != nil {
+				m.Sensor.State.StatFreeThr = types.Float64Value(*got.Sensor.State.StatFreeThr)
+			}
+			if got.Sensor.State.SleepFreeThr != nil {
+				m.Sensor.State.SleepFreeThr = types.Float64Value(*got.Sensor.State.SleepFreeThr)
+			}
+		}
+	}
+	if got.UI != nil {
+		if m.UI == nil {
+			m.UI = &presenceConfigUIModel{}
+		}
+		if got.UI.Imperial != nil {
+			m.UI.Imperial = types.BoolValue(*got.UI.Imperial)
+		}
+	}
+	if got.Leds != nil {
+		if m.Leds == nil {
+			m.Leds = &presenceConfigLedsModel{}
+		}
+		if got.Leds.Brightness != nil {
+			m.Leds.Brightness = types.BoolValue(*got.Leds.Brightness)
+		}
+		if got.Leds.NightMode != nil {
+			if m.Leds.NightMode == nil {
+				m.Leds.NightMode = &presenceConfigLedsNightModeModel{}
+			}
+			if got.Leds.NightMode.Enable != nil {
+				m.Leds.NightMode.Enable = types.BoolValue(*got.Leds.NightMode.Enable)
+			}
+			if got.Leds.NightMode.Brightness != nil {
+				m.Leds.NightMode.Brightness = types.Float64Value(*got.Leds.NightMode.Brightness)
+			}
+		}
+	}
+	if got.MainZone != nil {
+		m.MainZone = types.StringValue(*got.MainZone)
+	}
+}
+
 func (r *presenceConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state presenceConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.PresenceGetConfigRequest{}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Enable != nil {
-		state.Enable = types.BoolValue(*got.Enable)
-	}
-	if got.Zmin != nil {
-		state.Zmin = types.Float64Value(*got.Zmin)
-	}
-	if got.Zmax != nil {
-		state.Zmax = types.Float64Value(*got.Zmax)
-	}
-	if got.Sensor != nil {
-		if state.Sensor == nil {
-			state.Sensor = &presenceConfigSensorModel{}
-		}
-		if got.Sensor.Flipped != nil {
-			state.Sensor.Flipped = types.BoolValue(*got.Sensor.Flipped)
-		}
-		if got.Sensor.Height != nil {
-			state.Sensor.Height = types.Float64Value(*got.Sensor.Height)
-		}
-		if got.Sensor.Tilt != nil {
-			state.Sensor.Tilt = types.Float64Value(*got.Sensor.Tilt)
-		}
-		if got.Sensor.Points != nil {
-			state.Sensor.Points = types.Float64Value(*got.Sensor.Points)
-		}
-		if got.Sensor.Velocity != nil {
-			state.Sensor.Velocity = types.Float64Value(*got.Sensor.Velocity)
-		}
-		if got.Sensor.Snr != nil {
-			state.Sensor.Snr = types.Float64Value(*got.Sensor.Snr)
-		}
-		if got.Sensor.MaxVelocity != nil {
-			state.Sensor.MaxVelocity = types.Float64Value(*got.Sensor.MaxVelocity)
-		}
-		if got.Sensor.Position != nil {
-			state.Sensor.Position = types.StringValue(*got.Sensor.Position)
-		}
-		if got.Sensor.Power != nil {
-			state.Sensor.Power = types.StringValue(*got.Sensor.Power)
-		}
-		if got.Sensor.Sensitivity != nil {
-			state.Sensor.Sensitivity = types.StringValue(*got.Sensor.Sensitivity)
-		}
-		if got.Sensor.State != nil {
-			if state.Sensor.State == nil {
-				state.Sensor.State = &presenceConfigSensorStateModel{}
-			}
-			if got.Sensor.State.DetActThr != nil {
-				state.Sensor.State.DetActThr = types.Float64Value(*got.Sensor.State.DetActThr)
-			}
-			if got.Sensor.State.DetFreeThr != nil {
-				state.Sensor.State.DetFreeThr = types.Float64Value(*got.Sensor.State.DetFreeThr)
-			}
-			if got.Sensor.State.ActFreeThr != nil {
-				state.Sensor.State.ActFreeThr = types.Float64Value(*got.Sensor.State.ActFreeThr)
-			}
-			if got.Sensor.State.StatFreeThr != nil {
-				state.Sensor.State.StatFreeThr = types.Float64Value(*got.Sensor.State.StatFreeThr)
-			}
-			if got.Sensor.State.SleepFreeThr != nil {
-				state.Sensor.State.SleepFreeThr = types.Float64Value(*got.Sensor.State.SleepFreeThr)
-			}
-		}
-	}
-	if got.UI != nil {
-		if state.UI == nil {
-			state.UI = &presenceConfigUIModel{}
-		}
-		if got.UI.Imperial != nil {
-			state.UI.Imperial = types.BoolValue(*got.UI.Imperial)
-		}
-	}
-	if got.Leds != nil {
-		if state.Leds == nil {
-			state.Leds = &presenceConfigLedsModel{}
-		}
-		if got.Leds.Brightness != nil {
-			state.Leds.Brightness = types.BoolValue(*got.Leds.Brightness)
-		}
-		if got.Leds.NightMode != nil {
-			if state.Leds.NightMode == nil {
-				state.Leds.NightMode = &presenceConfigLedsNightModeModel{}
-			}
-			if got.Leds.NightMode.Enable != nil {
-				state.Leds.NightMode.Enable = types.BoolValue(*got.Leds.NightMode.Enable)
-			}
-			if got.Leds.NightMode.Brightness != nil {
-				state.Leds.NightMode.Brightness = types.Float64Value(*got.Leds.NightMode.Brightness)
-			}
-		}
-	}
-	if got.MainZone != nil {
-		state.MainZone = types.StringValue(*got.MainZone)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *presenceConfigResource) apply(plan presenceConfigResourceModel, diags *diag.Diagnostics) {
+func (r *presenceConfigResource) apply(ctx context.Context, plan presenceConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.PresenceConfig
 	if !plan.Enable.IsNull() && !plan.Enable.IsUnknown() {
 		v := plan.Enable.ValueBool()
@@ -493,7 +500,11 @@ func (r *presenceConfigResource) Create(ctx context.Context, req resource.Create
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -506,7 +517,11 @@ func (r *presenceConfigResource) Update(ctx context.Context, req resource.Update
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/presencezone_config_resource_gen.go
+++ b/internal/provider/presencezone_config_resource_gen.go
@@ -75,36 +75,43 @@ func (r *presencezoneConfigResource) Schema(_ context.Context, _ resource.Schema
 	}
 }
 
+func (r *presencezoneConfigResource) get(ctx context.Context, m *presencezoneConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.PresenceZoneGetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Name != nil {
+		m.Name = types.StringValue(*got.Name)
+	}
+	if got.Enable != nil {
+		m.Enable = types.BoolValue(*got.Enable)
+	}
+	if got.PresenceDelay != nil {
+		m.PresenceDelay = types.Float64Value(*got.PresenceDelay)
+	}
+	if got.AbsenceDelay != nil {
+		m.AbsenceDelay = types.Float64Value(*got.AbsenceDelay)
+	}
+}
+
 func (r *presencezoneConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state presencezoneConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.PresenceZoneGetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Name != nil {
-		state.Name = types.StringValue(*got.Name)
-	}
-	if got.Enable != nil {
-		state.Enable = types.BoolValue(*got.Enable)
-	}
-	if got.PresenceDelay != nil {
-		state.PresenceDelay = types.Float64Value(*got.PresenceDelay)
-	}
-	if got.AbsenceDelay != nil {
-		state.AbsenceDelay = types.Float64Value(*got.AbsenceDelay)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *presencezoneConfigResource) apply(plan presencezoneConfigResourceModel, diags *diag.Diagnostics) {
+func (r *presencezoneConfigResource) apply(ctx context.Context, plan presencezoneConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.PresenceZoneConfig
 	cfg.ID = int(plan.ID.ValueInt64())
 	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
@@ -137,7 +144,11 @@ func (r *presencezoneConfigResource) Create(ctx context.Context, req resource.Cr
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -150,7 +161,11 @@ func (r *presencezoneConfigResource) Update(ctx context.Context, req resource.Up
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/rgb_config_resource_gen.go
+++ b/internal/provider/rgb_config_resource_gen.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -33,12 +34,15 @@ func NewRGBConfigResource() resource.Resource { return &rgbConfigResource{} }
 type rgbConfigResource struct{}
 
 type rgbConfigNightModeModel struct {
-	Enable     types.Bool    `tfsdk:"enable"`
-	Brightness types.Float64 `tfsdk:"brightness"`
+	Enable        types.Bool    `tfsdk:"enable"`
+	Brightness    types.Float64 `tfsdk:"brightness"`
+	RGB           types.List    `tfsdk:"rgb"`
+	ActiveBetween types.List    `tfsdk:"active_between"`
 }
 
 type rgbConfigButtonPresetsButtonDoublepushModel struct {
 	Brightness types.Float64 `tfsdk:"brightness"`
+	RGB        types.List    `tfsdk:"rgb"`
 }
 
 type rgbConfigButtonPresetsModel struct {
@@ -147,6 +151,20 @@ func (r *rgbConfigResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 						MarkdownDescription: "Brightness level limit (in percent) when night mode is active. null overrides night_mode.brightness with current brightness when night mode starts. Default value 50.",
 						PlanModifiers:       []planmodifier.Float64{float64planmodifier.UseStateForUnknown()},
 					},
+					"rgb": schema.ListAttribute{
+						ElementType:         types.Float64Type,
+						Optional:            true,
+						Computed:            true,
+						MarkdownDescription: "Color level when night mode is active. Red, Green, Blue [r,g,b] - each value represents level between 0..255. null overrides night_mode.rgb array with current rgb array when night mode starts. Default value 255 for each color",
+						PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+					},
+					"active_between": schema.ListAttribute{
+						ElementType:         types.StringType,
+						Optional:            true,
+						Computed:            true,
+						MarkdownDescription: "Containing 2 elements of type string, the first element indicates the start of the period during which the night mode will be active, the second indicates the end of that period. Both start and end are strings in the format HH:MM, where HH and MM are hours and minutes with optinal leading zeros",
+						PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+					},
 				},
 			},
 			"button_fade_rate": schema.Float64Attribute{
@@ -170,6 +188,13 @@ func (r *rgbConfigResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Computed:            true,
 								MarkdownDescription: "Brightness level (in percent) set on double click (if applicable). null overrides brightness with current brightness when preset is applied. Default 100",
 								PlanModifiers:       []planmodifier.Float64{float64planmodifier.UseStateForUnknown()},
+							},
+							"rgb": schema.ListAttribute{
+								ElementType:         types.Float64Type,
+								Optional:            true,
+								Computed:            true,
+								MarkdownDescription: "Color level set on double click (if applicable). Red, Green, Blue [r,g,b] - each value represents level between 0..255. null overrides rgb array with current rgb array when preset is applied. Default value 255 for each color",
+								PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
 							},
 						},
 					},
@@ -197,87 +222,109 @@ func (r *rgbConfigResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 	}
 }
 
+func (r *rgbConfigResource) get(ctx context.Context, m *rgbConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.RGBGetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Name != nil {
+		m.Name = types.StringValue(*got.Name)
+	}
+	if got.InMode != nil {
+		m.InMode = types.StringValue(*got.InMode)
+	}
+	if got.InitialState != nil {
+		m.InitialState = types.StringValue(*got.InitialState)
+	}
+	if got.AutoOn != nil {
+		m.AutoOn = types.BoolValue(*got.AutoOn)
+	}
+	if got.AutoOnDelay != nil {
+		m.AutoOnDelay = types.Float64Value(*got.AutoOnDelay)
+	}
+	if got.AutoOff != nil {
+		m.AutoOff = types.BoolValue(*got.AutoOff)
+	}
+	if got.AutoOffDelay != nil {
+		m.AutoOffDelay = types.Float64Value(*got.AutoOffDelay)
+	}
+	if got.TransitionDuration != nil {
+		m.TransitionDuration = types.Float64Value(*got.TransitionDuration)
+	}
+	if got.MinBrightnessOnToggle != nil {
+		m.MinBrightnessOnToggle = types.Float64Value(*got.MinBrightnessOnToggle)
+	}
+	if got.NightMode != nil {
+		if m.NightMode == nil {
+			m.NightMode = &rgbConfigNightModeModel{}
+		}
+		if got.NightMode.Enable != nil {
+			m.NightMode.Enable = types.BoolValue(*got.NightMode.Enable)
+		}
+		if got.NightMode.Brightness != nil {
+			m.NightMode.Brightness = types.Float64Value(*got.NightMode.Brightness)
+		}
+		if got.NightMode.RGB != nil {
+			l, d := types.ListValueFrom(ctx, types.Float64Type, got.NightMode.RGB)
+			diags.Append(d...)
+			m.NightMode.RGB = l
+		}
+		if got.NightMode.ActiveBetween != nil {
+			l, d := types.ListValueFrom(ctx, types.StringType, got.NightMode.ActiveBetween)
+			diags.Append(d...)
+			m.NightMode.ActiveBetween = l
+		}
+	}
+	if got.ButtonFadeRate != nil {
+		m.ButtonFadeRate = types.Float64Value(*got.ButtonFadeRate)
+	}
+	if got.ButtonPresets != nil {
+		if m.ButtonPresets == nil {
+			m.ButtonPresets = &rgbConfigButtonPresetsModel{}
+		}
+		if got.ButtonPresets.ButtonDoublepush != nil {
+			if m.ButtonPresets.ButtonDoublepush == nil {
+				m.ButtonPresets.ButtonDoublepush = &rgbConfigButtonPresetsButtonDoublepushModel{}
+			}
+			if got.ButtonPresets.ButtonDoublepush.Brightness != nil {
+				m.ButtonPresets.ButtonDoublepush.Brightness = types.Float64Value(*got.ButtonPresets.ButtonDoublepush.Brightness)
+			}
+			if got.ButtonPresets.ButtonDoublepush.RGB != nil {
+				l, d := types.ListValueFrom(ctx, types.Float64Type, got.ButtonPresets.ButtonDoublepush.RGB)
+				diags.Append(d...)
+				m.ButtonPresets.ButtonDoublepush.RGB = l
+			}
+		}
+	}
+	if got.CurrentLimit != nil {
+		m.CurrentLimit = types.Float64Value(*got.CurrentLimit)
+	}
+	if got.PowerLimit != nil {
+		m.PowerLimit = types.Float64Value(*got.PowerLimit)
+	}
+	if got.VoltageLimit != nil {
+		m.VoltageLimit = types.Float64Value(*got.VoltageLimit)
+	}
+}
+
 func (r *rgbConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state rgbConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.RGBGetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Name != nil {
-		state.Name = types.StringValue(*got.Name)
-	}
-	if got.InMode != nil {
-		state.InMode = types.StringValue(*got.InMode)
-	}
-	if got.InitialState != nil {
-		state.InitialState = types.StringValue(*got.InitialState)
-	}
-	if got.AutoOn != nil {
-		state.AutoOn = types.BoolValue(*got.AutoOn)
-	}
-	if got.AutoOnDelay != nil {
-		state.AutoOnDelay = types.Float64Value(*got.AutoOnDelay)
-	}
-	if got.AutoOff != nil {
-		state.AutoOff = types.BoolValue(*got.AutoOff)
-	}
-	if got.AutoOffDelay != nil {
-		state.AutoOffDelay = types.Float64Value(*got.AutoOffDelay)
-	}
-	if got.TransitionDuration != nil {
-		state.TransitionDuration = types.Float64Value(*got.TransitionDuration)
-	}
-	if got.MinBrightnessOnToggle != nil {
-		state.MinBrightnessOnToggle = types.Float64Value(*got.MinBrightnessOnToggle)
-	}
-	if got.NightMode != nil {
-		if state.NightMode == nil {
-			state.NightMode = &rgbConfigNightModeModel{}
-		}
-		if got.NightMode.Enable != nil {
-			state.NightMode.Enable = types.BoolValue(*got.NightMode.Enable)
-		}
-		if got.NightMode.Brightness != nil {
-			state.NightMode.Brightness = types.Float64Value(*got.NightMode.Brightness)
-		}
-	}
-	if got.ButtonFadeRate != nil {
-		state.ButtonFadeRate = types.Float64Value(*got.ButtonFadeRate)
-	}
-	if got.ButtonPresets != nil {
-		if state.ButtonPresets == nil {
-			state.ButtonPresets = &rgbConfigButtonPresetsModel{}
-		}
-		if got.ButtonPresets.ButtonDoublepush != nil {
-			if state.ButtonPresets.ButtonDoublepush == nil {
-				state.ButtonPresets.ButtonDoublepush = &rgbConfigButtonPresetsButtonDoublepushModel{}
-			}
-			if got.ButtonPresets.ButtonDoublepush.Brightness != nil {
-				state.ButtonPresets.ButtonDoublepush.Brightness = types.Float64Value(*got.ButtonPresets.ButtonDoublepush.Brightness)
-			}
-		}
-	}
-	if got.CurrentLimit != nil {
-		state.CurrentLimit = types.Float64Value(*got.CurrentLimit)
-	}
-	if got.PowerLimit != nil {
-		state.PowerLimit = types.Float64Value(*got.PowerLimit)
-	}
-	if got.VoltageLimit != nil {
-		state.VoltageLimit = types.Float64Value(*got.VoltageLimit)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *rgbConfigResource) apply(plan rgbConfigResourceModel, diags *diag.Diagnostics) {
+func (r *rgbConfigResource) apply(ctx context.Context, plan rgbConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.RGBConfig
 	cfg.ID = int(plan.ID.ValueInt64())
 	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
@@ -326,6 +373,16 @@ func (r *rgbConfigResource) apply(plan rgbConfigResourceModel, diags *diag.Diagn
 			v := plan.NightMode.Brightness.ValueFloat64()
 			cfg.NightMode.Brightness = &v
 		}
+		if !plan.NightMode.RGB.IsNull() && !plan.NightMode.RGB.IsUnknown() {
+			var v []float64
+			diags.Append(plan.NightMode.RGB.ElementsAs(ctx, &v, false)...)
+			cfg.NightMode.RGB = v
+		}
+		if !plan.NightMode.ActiveBetween.IsNull() && !plan.NightMode.ActiveBetween.IsUnknown() {
+			var v []string
+			diags.Append(plan.NightMode.ActiveBetween.ElementsAs(ctx, &v, false)...)
+			cfg.NightMode.ActiveBetween = v
+		}
 	}
 	if !plan.ButtonFadeRate.IsNull() && !plan.ButtonFadeRate.IsUnknown() {
 		v := plan.ButtonFadeRate.ValueFloat64()
@@ -338,6 +395,11 @@ func (r *rgbConfigResource) apply(plan rgbConfigResourceModel, diags *diag.Diagn
 			if !plan.ButtonPresets.ButtonDoublepush.Brightness.IsNull() && !plan.ButtonPresets.ButtonDoublepush.Brightness.IsUnknown() {
 				v := plan.ButtonPresets.ButtonDoublepush.Brightness.ValueFloat64()
 				cfg.ButtonPresets.ButtonDoublepush.Brightness = &v
+			}
+			if !plan.ButtonPresets.ButtonDoublepush.RGB.IsNull() && !plan.ButtonPresets.ButtonDoublepush.RGB.IsUnknown() {
+				var v []float64
+				diags.Append(plan.ButtonPresets.ButtonDoublepush.RGB.ElementsAs(ctx, &v, false)...)
+				cfg.ButtonPresets.ButtonDoublepush.RGB = v
 			}
 		}
 	}
@@ -367,7 +429,11 @@ func (r *rgbConfigResource) Create(ctx context.Context, req resource.CreateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -380,7 +446,11 @@ func (r *rgbConfigResource) Update(ctx context.Context, req resource.UpdateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/rgbcct_config_resource_gen.go
+++ b/internal/provider/rgbcct_config_resource_gen.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -33,10 +34,12 @@ func NewRGBCCTConfigResource() resource.Resource { return &rgbcctConfigResource{
 type rgbcctConfigResource struct{}
 
 type rgbcctConfigNightModeModel struct {
-	Enable     types.Bool    `tfsdk:"enable"`
-	Brightness types.Float64 `tfsdk:"brightness"`
-	Ct         types.Float64 `tfsdk:"ct"`
-	Mode       types.String  `tfsdk:"mode"`
+	Enable        types.Bool    `tfsdk:"enable"`
+	Brightness    types.Float64 `tfsdk:"brightness"`
+	RGB           types.List    `tfsdk:"rgb"`
+	Ct            types.Float64 `tfsdk:"ct"`
+	Mode          types.String  `tfsdk:"mode"`
+	ActiveBetween types.List    `tfsdk:"active_between"`
 }
 
 type rgbcctConfigResourceModel struct {
@@ -128,6 +131,13 @@ func (r *rgbcctConfigResource) Schema(_ context.Context, _ resource.SchemaReques
 						MarkdownDescription: "Brightness level limit (in percent) when night mode is active. null overrides night_mode.brightness with current brightness when night mode starts. Default value 50.",
 						PlanModifiers:       []planmodifier.Float64{float64planmodifier.UseStateForUnknown()},
 					},
+					"rgb": schema.ListAttribute{
+						ElementType:         types.Float64Type,
+						Optional:            true,
+						Computed:            true,
+						MarkdownDescription: "Color level when night mode is active. Red, Green, Blue [r,g,b] - each value represents level between 0..255. null overrides night_mode.rgb array with current rgb array when night mode starts. Default value 255 for each color",
+						PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+					},
 					"ct": schema.Float64Attribute{
 						Optional:            true,
 						Computed:            true,
@@ -141,9 +151,78 @@ func (r *rgbcctConfigResource) Schema(_ context.Context, _ resource.SchemaReques
 						Validators:          []validator.String{stringvalidator.OneOf("rgb")},
 						PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 					},
+					"active_between": schema.ListAttribute{
+						ElementType:         types.StringType,
+						Optional:            true,
+						Computed:            true,
+						MarkdownDescription: "Containing 2 elements of type string, the first element indicates the start of the period during which the night mode will be active, the second indicates the end of that period. Both start and end are strings in the format HH:MM, where HH and MM are hours and minutes with optinal leading zeros",
+						PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+					},
 				},
 			},
 		},
+	}
+}
+
+func (r *rgbcctConfigResource) get(ctx context.Context, m *rgbcctConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.RGBCCTGetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Name != nil {
+		m.Name = types.StringValue(*got.Name)
+	}
+	if got.InitialState != nil {
+		m.InitialState = types.StringValue(*got.InitialState)
+	}
+	if got.AutoOn != nil {
+		m.AutoOn = types.BoolValue(*got.AutoOn)
+	}
+	if got.AutoOnDelay != nil {
+		m.AutoOnDelay = types.Float64Value(*got.AutoOnDelay)
+	}
+	if got.AutoOff != nil {
+		m.AutoOff = types.BoolValue(*got.AutoOff)
+	}
+	if got.AutoOffDelay != nil {
+		m.AutoOffDelay = types.Float64Value(*got.AutoOffDelay)
+	}
+	if got.TransitionDuration != nil {
+		m.TransitionDuration = types.Float64Value(*got.TransitionDuration)
+	}
+	if got.MinBrightnessOnToggle != nil {
+		m.MinBrightnessOnToggle = types.Float64Value(*got.MinBrightnessOnToggle)
+	}
+	if got.NightMode != nil {
+		if m.NightMode == nil {
+			m.NightMode = &rgbcctConfigNightModeModel{}
+		}
+		if got.NightMode.Enable != nil {
+			m.NightMode.Enable = types.BoolValue(*got.NightMode.Enable)
+		}
+		if got.NightMode.Brightness != nil {
+			m.NightMode.Brightness = types.Float64Value(*got.NightMode.Brightness)
+		}
+		if got.NightMode.RGB != nil {
+			l, d := types.ListValueFrom(ctx, types.Float64Type, got.NightMode.RGB)
+			diags.Append(d...)
+			m.NightMode.RGB = l
+		}
+		if got.NightMode.Ct != nil {
+			m.NightMode.Ct = types.Float64Value(*got.NightMode.Ct)
+		}
+		if got.NightMode.Mode != nil {
+			m.NightMode.Mode = types.StringValue(*got.NightMode.Mode)
+		}
+		if got.NightMode.ActiveBetween != nil {
+			l, d := types.ListValueFrom(ctx, types.StringType, got.NightMode.ActiveBetween)
+			diags.Append(d...)
+			m.NightMode.ActiveBetween = l
+		}
 	}
 }
 
@@ -153,59 +232,14 @@ func (r *rgbcctConfigResource) Read(ctx context.Context, req resource.ReadReques
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.RGBCCTGetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Name != nil {
-		state.Name = types.StringValue(*got.Name)
-	}
-	if got.InitialState != nil {
-		state.InitialState = types.StringValue(*got.InitialState)
-	}
-	if got.AutoOn != nil {
-		state.AutoOn = types.BoolValue(*got.AutoOn)
-	}
-	if got.AutoOnDelay != nil {
-		state.AutoOnDelay = types.Float64Value(*got.AutoOnDelay)
-	}
-	if got.AutoOff != nil {
-		state.AutoOff = types.BoolValue(*got.AutoOff)
-	}
-	if got.AutoOffDelay != nil {
-		state.AutoOffDelay = types.Float64Value(*got.AutoOffDelay)
-	}
-	if got.TransitionDuration != nil {
-		state.TransitionDuration = types.Float64Value(*got.TransitionDuration)
-	}
-	if got.MinBrightnessOnToggle != nil {
-		state.MinBrightnessOnToggle = types.Float64Value(*got.MinBrightnessOnToggle)
-	}
-	if got.NightMode != nil {
-		if state.NightMode == nil {
-			state.NightMode = &rgbcctConfigNightModeModel{}
-		}
-		if got.NightMode.Enable != nil {
-			state.NightMode.Enable = types.BoolValue(*got.NightMode.Enable)
-		}
-		if got.NightMode.Brightness != nil {
-			state.NightMode.Brightness = types.Float64Value(*got.NightMode.Brightness)
-		}
-		if got.NightMode.Ct != nil {
-			state.NightMode.Ct = types.Float64Value(*got.NightMode.Ct)
-		}
-		if got.NightMode.Mode != nil {
-			state.NightMode.Mode = types.StringValue(*got.NightMode.Mode)
-		}
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *rgbcctConfigResource) apply(plan rgbcctConfigResourceModel, diags *diag.Diagnostics) {
+func (r *rgbcctConfigResource) apply(ctx context.Context, plan rgbcctConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.RGBCCTConfig
 	cfg.ID = int(plan.ID.ValueInt64())
 	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
@@ -250,6 +284,11 @@ func (r *rgbcctConfigResource) apply(plan rgbcctConfigResourceModel, diags *diag
 			v := plan.NightMode.Brightness.ValueFloat64()
 			cfg.NightMode.Brightness = &v
 		}
+		if !plan.NightMode.RGB.IsNull() && !plan.NightMode.RGB.IsUnknown() {
+			var v []float64
+			diags.Append(plan.NightMode.RGB.ElementsAs(ctx, &v, false)...)
+			cfg.NightMode.RGB = v
+		}
 		if !plan.NightMode.Ct.IsNull() && !plan.NightMode.Ct.IsUnknown() {
 			v := plan.NightMode.Ct.ValueFloat64()
 			cfg.NightMode.Ct = &v
@@ -257,6 +296,11 @@ func (r *rgbcctConfigResource) apply(plan rgbcctConfigResourceModel, diags *diag
 		if !plan.NightMode.Mode.IsNull() && !plan.NightMode.Mode.IsUnknown() {
 			v := plan.NightMode.Mode.ValueString()
 			cfg.NightMode.Mode = &v
+		}
+		if !plan.NightMode.ActiveBetween.IsNull() && !plan.NightMode.ActiveBetween.IsUnknown() {
+			var v []string
+			diags.Append(plan.NightMode.ActiveBetween.ElementsAs(ctx, &v, false)...)
+			cfg.NightMode.ActiveBetween = v
 		}
 	}
 	client := resty.New()
@@ -273,7 +317,11 @@ func (r *rgbcctConfigResource) Create(ctx context.Context, req resource.CreateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -286,7 +334,11 @@ func (r *rgbcctConfigResource) Update(ctx context.Context, req resource.UpdateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/rgbw_config_resource_gen.go
+++ b/internal/provider/rgbw_config_resource_gen.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -33,13 +34,16 @@ func NewRGBWConfigResource() resource.Resource { return &rgbwConfigResource{} }
 type rgbwConfigResource struct{}
 
 type rgbwConfigNightModeModel struct {
-	Enable     types.Bool    `tfsdk:"enable"`
-	Brightness types.Float64 `tfsdk:"brightness"`
-	White      types.Float64 `tfsdk:"white"`
+	Enable        types.Bool    `tfsdk:"enable"`
+	Brightness    types.Float64 `tfsdk:"brightness"`
+	RGB           types.List    `tfsdk:"rgb"`
+	White         types.Float64 `tfsdk:"white"`
+	ActiveBetween types.List    `tfsdk:"active_between"`
 }
 
 type rgbwConfigButtonPresetsButtonDoublepushModel struct {
 	Brightness types.Float64 `tfsdk:"brightness"`
+	RGB        types.List    `tfsdk:"rgb"`
 	White      types.Float64 `tfsdk:"white"`
 }
 
@@ -149,11 +153,25 @@ func (r *rgbwConfigResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						MarkdownDescription: "Brightness level limit (in percent) when night mode is active. null overrides night_mode.brightness with current brightness when night mode starts. Default value 50.",
 						PlanModifiers:       []planmodifier.Float64{float64planmodifier.UseStateForUnknown()},
 					},
+					"rgb": schema.ListAttribute{
+						ElementType:         types.Float64Type,
+						Optional:            true,
+						Computed:            true,
+						MarkdownDescription: "Color level when night mode is active. Red, Green, Blue [r,g,b] - each value represents level between 0..255. null overrides night_mode.rgb array with current rgb array when night mode starts. Default value 255 for each color",
+						PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
+					},
 					"white": schema.Float64Attribute{
 						Optional:            true,
 						Computed:            true,
 						MarkdownDescription: "White level limit (in percent) when night mode is active. null overrides night_mode.white with current white when night mode starts. Default value 127.",
 						PlanModifiers:       []planmodifier.Float64{float64planmodifier.UseStateForUnknown()},
+					},
+					"active_between": schema.ListAttribute{
+						ElementType:         types.StringType,
+						Optional:            true,
+						Computed:            true,
+						MarkdownDescription: "Containing 2 elements of type string, the first element indicates the start of the period during which the night mode will be active, the second indicates the end of that period. Both start and end are strings in the format HH:MM, where HH and MM are hours and minutes with optinal leading zeros",
+						PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
 					},
 				},
 			},
@@ -178,6 +196,13 @@ func (r *rgbwConfigResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Computed:            true,
 								MarkdownDescription: "Brightness level (in percent) set on double click (if applicable). null overrides brightness with current brightness when preset is applied. Default 100",
 								PlanModifiers:       []planmodifier.Float64{float64planmodifier.UseStateForUnknown()},
+							},
+							"rgb": schema.ListAttribute{
+								ElementType:         types.Float64Type,
+								Optional:            true,
+								Computed:            true,
+								MarkdownDescription: "Color level set on double click (if applicable). Red, Green, Blue [r,g,b] - each value represents level between 0..255. null overrides rgb array with current rgb array when preset is applied. Default value 255 for each color",
+								PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
 							},
 							"white": schema.Float64Attribute{
 								Optional:            true,
@@ -211,93 +236,115 @@ func (r *rgbwConfigResource) Schema(_ context.Context, _ resource.SchemaRequest,
 	}
 }
 
+func (r *rgbwConfigResource) get(ctx context.Context, m *rgbwConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.RGBWGetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Name != nil {
+		m.Name = types.StringValue(*got.Name)
+	}
+	if got.InMode != nil {
+		m.InMode = types.StringValue(*got.InMode)
+	}
+	if got.InitialState != nil {
+		m.InitialState = types.StringValue(*got.InitialState)
+	}
+	if got.AutoOn != nil {
+		m.AutoOn = types.BoolValue(*got.AutoOn)
+	}
+	if got.AutoOnDelay != nil {
+		m.AutoOnDelay = types.Float64Value(*got.AutoOnDelay)
+	}
+	if got.AutoOff != nil {
+		m.AutoOff = types.BoolValue(*got.AutoOff)
+	}
+	if got.AutoOffDelay != nil {
+		m.AutoOffDelay = types.Float64Value(*got.AutoOffDelay)
+	}
+	if got.TransitionDuration != nil {
+		m.TransitionDuration = types.Float64Value(*got.TransitionDuration)
+	}
+	if got.MinBrightnessOnToggle != nil {
+		m.MinBrightnessOnToggle = types.Float64Value(*got.MinBrightnessOnToggle)
+	}
+	if got.NightMode != nil {
+		if m.NightMode == nil {
+			m.NightMode = &rgbwConfigNightModeModel{}
+		}
+		if got.NightMode.Enable != nil {
+			m.NightMode.Enable = types.BoolValue(*got.NightMode.Enable)
+		}
+		if got.NightMode.Brightness != nil {
+			m.NightMode.Brightness = types.Float64Value(*got.NightMode.Brightness)
+		}
+		if got.NightMode.RGB != nil {
+			l, d := types.ListValueFrom(ctx, types.Float64Type, got.NightMode.RGB)
+			diags.Append(d...)
+			m.NightMode.RGB = l
+		}
+		if got.NightMode.White != nil {
+			m.NightMode.White = types.Float64Value(*got.NightMode.White)
+		}
+		if got.NightMode.ActiveBetween != nil {
+			l, d := types.ListValueFrom(ctx, types.StringType, got.NightMode.ActiveBetween)
+			diags.Append(d...)
+			m.NightMode.ActiveBetween = l
+		}
+	}
+	if got.ButtonFadeRate != nil {
+		m.ButtonFadeRate = types.Float64Value(*got.ButtonFadeRate)
+	}
+	if got.ButtonPresets != nil {
+		if m.ButtonPresets == nil {
+			m.ButtonPresets = &rgbwConfigButtonPresetsModel{}
+		}
+		if got.ButtonPresets.ButtonDoublepush != nil {
+			if m.ButtonPresets.ButtonDoublepush == nil {
+				m.ButtonPresets.ButtonDoublepush = &rgbwConfigButtonPresetsButtonDoublepushModel{}
+			}
+			if got.ButtonPresets.ButtonDoublepush.Brightness != nil {
+				m.ButtonPresets.ButtonDoublepush.Brightness = types.Float64Value(*got.ButtonPresets.ButtonDoublepush.Brightness)
+			}
+			if got.ButtonPresets.ButtonDoublepush.RGB != nil {
+				l, d := types.ListValueFrom(ctx, types.Float64Type, got.ButtonPresets.ButtonDoublepush.RGB)
+				diags.Append(d...)
+				m.ButtonPresets.ButtonDoublepush.RGB = l
+			}
+			if got.ButtonPresets.ButtonDoublepush.White != nil {
+				m.ButtonPresets.ButtonDoublepush.White = types.Float64Value(*got.ButtonPresets.ButtonDoublepush.White)
+			}
+		}
+	}
+	if got.CurrentLimit != nil {
+		m.CurrentLimit = types.Float64Value(*got.CurrentLimit)
+	}
+	if got.PowerLimit != nil {
+		m.PowerLimit = types.Float64Value(*got.PowerLimit)
+	}
+	if got.VoltageLimit != nil {
+		m.VoltageLimit = types.Float64Value(*got.VoltageLimit)
+	}
+}
+
 func (r *rgbwConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state rgbwConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.RGBWGetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Name != nil {
-		state.Name = types.StringValue(*got.Name)
-	}
-	if got.InMode != nil {
-		state.InMode = types.StringValue(*got.InMode)
-	}
-	if got.InitialState != nil {
-		state.InitialState = types.StringValue(*got.InitialState)
-	}
-	if got.AutoOn != nil {
-		state.AutoOn = types.BoolValue(*got.AutoOn)
-	}
-	if got.AutoOnDelay != nil {
-		state.AutoOnDelay = types.Float64Value(*got.AutoOnDelay)
-	}
-	if got.AutoOff != nil {
-		state.AutoOff = types.BoolValue(*got.AutoOff)
-	}
-	if got.AutoOffDelay != nil {
-		state.AutoOffDelay = types.Float64Value(*got.AutoOffDelay)
-	}
-	if got.TransitionDuration != nil {
-		state.TransitionDuration = types.Float64Value(*got.TransitionDuration)
-	}
-	if got.MinBrightnessOnToggle != nil {
-		state.MinBrightnessOnToggle = types.Float64Value(*got.MinBrightnessOnToggle)
-	}
-	if got.NightMode != nil {
-		if state.NightMode == nil {
-			state.NightMode = &rgbwConfigNightModeModel{}
-		}
-		if got.NightMode.Enable != nil {
-			state.NightMode.Enable = types.BoolValue(*got.NightMode.Enable)
-		}
-		if got.NightMode.Brightness != nil {
-			state.NightMode.Brightness = types.Float64Value(*got.NightMode.Brightness)
-		}
-		if got.NightMode.White != nil {
-			state.NightMode.White = types.Float64Value(*got.NightMode.White)
-		}
-	}
-	if got.ButtonFadeRate != nil {
-		state.ButtonFadeRate = types.Float64Value(*got.ButtonFadeRate)
-	}
-	if got.ButtonPresets != nil {
-		if state.ButtonPresets == nil {
-			state.ButtonPresets = &rgbwConfigButtonPresetsModel{}
-		}
-		if got.ButtonPresets.ButtonDoublepush != nil {
-			if state.ButtonPresets.ButtonDoublepush == nil {
-				state.ButtonPresets.ButtonDoublepush = &rgbwConfigButtonPresetsButtonDoublepushModel{}
-			}
-			if got.ButtonPresets.ButtonDoublepush.Brightness != nil {
-				state.ButtonPresets.ButtonDoublepush.Brightness = types.Float64Value(*got.ButtonPresets.ButtonDoublepush.Brightness)
-			}
-			if got.ButtonPresets.ButtonDoublepush.White != nil {
-				state.ButtonPresets.ButtonDoublepush.White = types.Float64Value(*got.ButtonPresets.ButtonDoublepush.White)
-			}
-		}
-	}
-	if got.CurrentLimit != nil {
-		state.CurrentLimit = types.Float64Value(*got.CurrentLimit)
-	}
-	if got.PowerLimit != nil {
-		state.PowerLimit = types.Float64Value(*got.PowerLimit)
-	}
-	if got.VoltageLimit != nil {
-		state.VoltageLimit = types.Float64Value(*got.VoltageLimit)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *rgbwConfigResource) apply(plan rgbwConfigResourceModel, diags *diag.Diagnostics) {
+func (r *rgbwConfigResource) apply(ctx context.Context, plan rgbwConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.RGBWConfig
 	cfg.ID = int(plan.ID.ValueInt64())
 	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
@@ -346,9 +393,19 @@ func (r *rgbwConfigResource) apply(plan rgbwConfigResourceModel, diags *diag.Dia
 			v := plan.NightMode.Brightness.ValueFloat64()
 			cfg.NightMode.Brightness = &v
 		}
+		if !plan.NightMode.RGB.IsNull() && !plan.NightMode.RGB.IsUnknown() {
+			var v []float64
+			diags.Append(plan.NightMode.RGB.ElementsAs(ctx, &v, false)...)
+			cfg.NightMode.RGB = v
+		}
 		if !plan.NightMode.White.IsNull() && !plan.NightMode.White.IsUnknown() {
 			v := plan.NightMode.White.ValueFloat64()
 			cfg.NightMode.White = &v
+		}
+		if !plan.NightMode.ActiveBetween.IsNull() && !plan.NightMode.ActiveBetween.IsUnknown() {
+			var v []string
+			diags.Append(plan.NightMode.ActiveBetween.ElementsAs(ctx, &v, false)...)
+			cfg.NightMode.ActiveBetween = v
 		}
 	}
 	if !plan.ButtonFadeRate.IsNull() && !plan.ButtonFadeRate.IsUnknown() {
@@ -362,6 +419,11 @@ func (r *rgbwConfigResource) apply(plan rgbwConfigResourceModel, diags *diag.Dia
 			if !plan.ButtonPresets.ButtonDoublepush.Brightness.IsNull() && !plan.ButtonPresets.ButtonDoublepush.Brightness.IsUnknown() {
 				v := plan.ButtonPresets.ButtonDoublepush.Brightness.ValueFloat64()
 				cfg.ButtonPresets.ButtonDoublepush.Brightness = &v
+			}
+			if !plan.ButtonPresets.ButtonDoublepush.RGB.IsNull() && !plan.ButtonPresets.ButtonDoublepush.RGB.IsUnknown() {
+				var v []float64
+				diags.Append(plan.ButtonPresets.ButtonDoublepush.RGB.ElementsAs(ctx, &v, false)...)
+				cfg.ButtonPresets.ButtonDoublepush.RGB = v
 			}
 			if !plan.ButtonPresets.ButtonDoublepush.White.IsNull() && !plan.ButtonPresets.ButtonDoublepush.White.IsUnknown() {
 				v := plan.ButtonPresets.ButtonDoublepush.White.ValueFloat64()
@@ -395,7 +457,11 @@ func (r *rgbwConfigResource) Create(ctx context.Context, req resource.CreateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -408,7 +474,11 @@ func (r *rgbwConfigResource) Update(ctx context.Context, req resource.UpdateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/script_config_resource_gen.go
+++ b/internal/provider/script_config_resource_gen.go
@@ -60,30 +60,37 @@ func (r *scriptConfigResource) Schema(_ context.Context, _ resource.SchemaReques
 	}
 }
 
+func (r *scriptConfigResource) get(ctx context.Context, m *scriptConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.ScriptGetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Name != nil {
+		m.Name = types.StringValue(*got.Name)
+	}
+	if got.Enable != nil {
+		m.Enable = types.BoolValue(*got.Enable)
+	}
+}
+
 func (r *scriptConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state scriptConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.ScriptGetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Name != nil {
-		state.Name = types.StringValue(*got.Name)
-	}
-	if got.Enable != nil {
-		state.Enable = types.BoolValue(*got.Enable)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *scriptConfigResource) apply(plan scriptConfigResourceModel, diags *diag.Diagnostics) {
+func (r *scriptConfigResource) apply(ctx context.Context, plan scriptConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.ScriptConfig
 	cfg.ID = int(plan.ID.ValueInt64())
 	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
@@ -108,7 +115,11 @@ func (r *scriptConfigResource) Create(ctx context.Context, req resource.CreateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -121,7 +132,11 @@ func (r *scriptConfigResource) Update(ctx context.Context, req resource.UpdateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/serial_config_resource_gen.go
+++ b/internal/provider/serial_config_resource_gen.go
@@ -112,52 +112,59 @@ func (r *serialConfigResource) Schema(_ context.Context, _ resource.SchemaReques
 	}
 }
 
+func (r *serialConfigResource) get(ctx context.Context, m *serialConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.SerialGetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Mode != nil {
+		m.Mode = types.StringValue(*got.Mode)
+	}
+	if got.Serial != nil {
+		if m.Serial == nil {
+			m.Serial = &serialConfigSerialModel{}
+		}
+		if got.Serial.Baud != nil {
+			m.Serial.Baud = types.Int64Value(int64(*got.Serial.Baud))
+		}
+		if got.Serial.Format != nil {
+			m.Serial.Format = types.StringValue(*got.Serial.Format)
+		}
+		if got.Serial.Hd != nil {
+			m.Serial.Hd = types.BoolValue(*got.Serial.Hd)
+		}
+		if got.Serial.DeAl != nil {
+			m.Serial.DeAl = types.BoolValue(*got.Serial.DeAl)
+		}
+	}
+	if got.MbServer != nil {
+		if m.MbServer == nil {
+			m.MbServer = &serialConfigMbServerModel{}
+		}
+		if got.MbServer.Addr != nil {
+			m.MbServer.Addr = types.Int64Value(int64(*got.MbServer.Addr))
+		}
+	}
+}
+
 func (r *serialConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state serialConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.SerialGetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Mode != nil {
-		state.Mode = types.StringValue(*got.Mode)
-	}
-	if got.Serial != nil {
-		if state.Serial == nil {
-			state.Serial = &serialConfigSerialModel{}
-		}
-		if got.Serial.Baud != nil {
-			state.Serial.Baud = types.Int64Value(int64(*got.Serial.Baud))
-		}
-		if got.Serial.Format != nil {
-			state.Serial.Format = types.StringValue(*got.Serial.Format)
-		}
-		if got.Serial.Hd != nil {
-			state.Serial.Hd = types.BoolValue(*got.Serial.Hd)
-		}
-		if got.Serial.DeAl != nil {
-			state.Serial.DeAl = types.BoolValue(*got.Serial.DeAl)
-		}
-	}
-	if got.MbServer != nil {
-		if state.MbServer == nil {
-			state.MbServer = &serialConfigMbServerModel{}
-		}
-		if got.MbServer.Addr != nil {
-			state.MbServer.Addr = types.Int64Value(int64(*got.MbServer.Addr))
-		}
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *serialConfigResource) apply(plan serialConfigResourceModel, diags *diag.Diagnostics) {
+func (r *serialConfigResource) apply(ctx context.Context, plan serialConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.SerialConfig
 	cfg.ID = int(plan.ID.ValueInt64())
 	if !plan.Mode.IsNull() && !plan.Mode.IsUnknown() {
@@ -204,7 +211,11 @@ func (r *serialConfigResource) Create(ctx context.Context, req resource.CreateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -217,7 +228,11 @@ func (r *serialConfigResource) Update(ctx context.Context, req resource.UpdateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/smoke_config_resource_gen.go
+++ b/internal/provider/smoke_config_resource_gen.go
@@ -52,27 +52,34 @@ func (r *smokeConfigResource) Schema(_ context.Context, _ resource.SchemaRequest
 	}
 }
 
+func (r *smokeConfigResource) get(ctx context.Context, m *smokeConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.SmokeGetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Name != nil {
+		m.Name = types.StringValue(*got.Name)
+	}
+}
+
 func (r *smokeConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state smokeConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.SmokeGetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Name != nil {
-		state.Name = types.StringValue(*got.Name)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *smokeConfigResource) apply(plan smokeConfigResourceModel, diags *diag.Diagnostics) {
+func (r *smokeConfigResource) apply(ctx context.Context, plan smokeConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.SmokeConfig
 	cfg.ID = int(plan.ID.ValueInt64())
 	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
@@ -93,7 +100,11 @@ func (r *smokeConfigResource) Create(ctx context.Context, req resource.CreateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -106,7 +117,11 @@ func (r *smokeConfigResource) Update(ctx context.Context, req resource.UpdateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/switch_config_resource_gen.go
+++ b/internal/provider/switch_config_resource_gen.go
@@ -182,80 +182,87 @@ func (r *switchConfigResource) Schema(_ context.Context, _ resource.SchemaReques
 	}
 }
 
+func (r *switchConfigResource) get(ctx context.Context, m *switchConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.SwitchGetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Name != nil {
+		m.Name = types.StringValue(*got.Name)
+	}
+	if got.InMode != nil {
+		m.InMode = types.StringValue(*got.InMode)
+	}
+	if got.InLocked != nil {
+		m.InLocked = types.BoolValue(*got.InLocked)
+	}
+	if got.InitialState != nil {
+		m.InitialState = types.StringValue(*got.InitialState)
+	}
+	if got.AutoOn != nil {
+		m.AutoOn = types.BoolValue(*got.AutoOn)
+	}
+	if got.AutoOnDelay != nil {
+		m.AutoOnDelay = types.Float64Value(*got.AutoOnDelay)
+	}
+	if got.AutoOff != nil {
+		m.AutoOff = types.BoolValue(*got.AutoOff)
+	}
+	if got.AutoOffDelay != nil {
+		m.AutoOffDelay = types.Float64Value(*got.AutoOffDelay)
+	}
+	if got.AutorecoverVoltageErrors != nil {
+		m.AutorecoverVoltageErrors = types.BoolValue(*got.AutorecoverVoltageErrors)
+	}
+	if got.InputID != nil {
+		m.InputID = types.Float64Value(*got.InputID)
+	}
+	if got.PowerLimit != nil {
+		m.PowerLimit = types.Float64Value(*got.PowerLimit)
+	}
+	if got.VoltageLimit != nil {
+		m.VoltageLimit = types.Float64Value(*got.VoltageLimit)
+	}
+	if got.UndervoltageLimit != nil {
+		m.UndervoltageLimit = types.Float64Value(*got.UndervoltageLimit)
+	}
+	if got.CurrentLimit != nil {
+		m.CurrentLimit = types.Float64Value(*got.CurrentLimit)
+	}
+	if got.Reverse != nil {
+		m.Reverse = types.BoolValue(*got.Reverse)
+	}
+	if got.Counts != nil {
+		if m.Counts == nil {
+			m.Counts = &switchConfigCountsModel{}
+		}
+		if got.Counts.Enable != nil {
+			m.Counts.Enable = types.BoolValue(*got.Counts.Enable)
+		}
+		if got.Counts.PowerThr != nil {
+			m.Counts.PowerThr = types.Float64Value(*got.Counts.PowerThr)
+		}
+	}
+}
+
 func (r *switchConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state switchConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.SwitchGetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Name != nil {
-		state.Name = types.StringValue(*got.Name)
-	}
-	if got.InMode != nil {
-		state.InMode = types.StringValue(*got.InMode)
-	}
-	if got.InLocked != nil {
-		state.InLocked = types.BoolValue(*got.InLocked)
-	}
-	if got.InitialState != nil {
-		state.InitialState = types.StringValue(*got.InitialState)
-	}
-	if got.AutoOn != nil {
-		state.AutoOn = types.BoolValue(*got.AutoOn)
-	}
-	if got.AutoOnDelay != nil {
-		state.AutoOnDelay = types.Float64Value(*got.AutoOnDelay)
-	}
-	if got.AutoOff != nil {
-		state.AutoOff = types.BoolValue(*got.AutoOff)
-	}
-	if got.AutoOffDelay != nil {
-		state.AutoOffDelay = types.Float64Value(*got.AutoOffDelay)
-	}
-	if got.AutorecoverVoltageErrors != nil {
-		state.AutorecoverVoltageErrors = types.BoolValue(*got.AutorecoverVoltageErrors)
-	}
-	if got.InputID != nil {
-		state.InputID = types.Float64Value(*got.InputID)
-	}
-	if got.PowerLimit != nil {
-		state.PowerLimit = types.Float64Value(*got.PowerLimit)
-	}
-	if got.VoltageLimit != nil {
-		state.VoltageLimit = types.Float64Value(*got.VoltageLimit)
-	}
-	if got.UndervoltageLimit != nil {
-		state.UndervoltageLimit = types.Float64Value(*got.UndervoltageLimit)
-	}
-	if got.CurrentLimit != nil {
-		state.CurrentLimit = types.Float64Value(*got.CurrentLimit)
-	}
-	if got.Reverse != nil {
-		state.Reverse = types.BoolValue(*got.Reverse)
-	}
-	if got.Counts != nil {
-		if state.Counts == nil {
-			state.Counts = &switchConfigCountsModel{}
-		}
-		if got.Counts.Enable != nil {
-			state.Counts.Enable = types.BoolValue(*got.Counts.Enable)
-		}
-		if got.Counts.PowerThr != nil {
-			state.Counts.PowerThr = types.Float64Value(*got.Counts.PowerThr)
-		}
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *switchConfigResource) apply(plan switchConfigResourceModel, diags *diag.Diagnostics) {
+func (r *switchConfigResource) apply(ctx context.Context, plan switchConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.SwitchConfig
 	cfg.ID = int(plan.ID.ValueInt64())
 	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
@@ -343,7 +350,11 @@ func (r *switchConfigResource) Create(ctx context.Context, req resource.CreateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -356,7 +367,11 @@ func (r *switchConfigResource) Update(ctx context.Context, req resource.UpdateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/sys_config_resource_gen.go
+++ b/internal/provider/sys_config_resource_gen.go
@@ -116,13 +116,11 @@ func (r *sysConfigResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 						PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 					},
 					"mac": schema.StringAttribute{
-						Optional:            true,
 						Computed:            true,
 						MarkdownDescription: "Read-only base MAC address of the device",
 						PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 					},
 					"fw_id": schema.StringAttribute{
-						Optional:            true,
 						Computed:            true,
 						MarkdownDescription: "Read-only build identifier of the current firmware image",
 						PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
@@ -292,132 +290,139 @@ func (r *sysConfigResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 	}
 }
 
+func (r *sysConfigResource) get(ctx context.Context, m *sysConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.SysGetConfigRequest{}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Device != nil {
+		if m.Device == nil {
+			m.Device = &sysConfigDeviceModel{}
+		}
+		if got.Device.Name != nil {
+			m.Device.Name = types.StringValue(*got.Device.Name)
+		}
+		if got.Device.EcoMode != nil {
+			m.Device.EcoMode = types.BoolValue(*got.Device.EcoMode)
+		}
+		if got.Device.MAC != nil {
+			m.Device.MAC = types.StringValue(*got.Device.MAC)
+		}
+		if got.Device.FWID != nil {
+			m.Device.FWID = types.StringValue(*got.Device.FWID)
+		}
+		if got.Device.Profile != nil {
+			m.Device.Profile = types.StringValue(*got.Device.Profile)
+		}
+		if got.Device.Discoverable != nil {
+			m.Device.Discoverable = types.BoolValue(*got.Device.Discoverable)
+		}
+		if got.Device.AddonType != nil {
+			m.Device.AddonType = types.StringValue(*got.Device.AddonType)
+		}
+		if got.Device.SysBtnToggle != nil {
+			m.Device.SysBtnToggle = types.BoolValue(*got.Device.SysBtnToggle)
+		}
+		if got.Device.TLSCheckCertValidityTime != nil {
+			m.Device.TLSCheckCertValidityTime = types.BoolValue(*got.Device.TLSCheckCertValidityTime)
+		}
+		if got.Device.EnhancedSecurity != nil {
+			m.Device.EnhancedSecurity = types.BoolValue(*got.Device.EnhancedSecurity)
+		}
+	}
+	if got.Location != nil {
+		if m.Location == nil {
+			m.Location = &sysConfigLocationModel{}
+		}
+		if got.Location.Tz != nil {
+			m.Location.Tz = types.StringValue(*got.Location.Tz)
+		}
+		if got.Location.Lat != nil {
+			m.Location.Lat = types.Float64Value(*got.Location.Lat)
+		}
+		if got.Location.Lon != nil {
+			m.Location.Lon = types.Float64Value(*got.Location.Lon)
+		}
+	}
+	if got.Debug != nil {
+		if m.Debug == nil {
+			m.Debug = &sysConfigDebugModel{}
+		}
+		if got.Debug.MQTT != nil {
+			if m.Debug.MQTT == nil {
+				m.Debug.MQTT = &sysConfigDebugMQTTModel{}
+			}
+			if got.Debug.MQTT.Enable != nil {
+				m.Debug.MQTT.Enable = types.BoolValue(*got.Debug.MQTT.Enable)
+			}
+		}
+		if got.Debug.Websocket != nil {
+			if m.Debug.Websocket == nil {
+				m.Debug.Websocket = &sysConfigDebugWebsocketModel{}
+			}
+			if got.Debug.Websocket.Enable != nil {
+				m.Debug.Websocket.Enable = types.BoolValue(*got.Debug.Websocket.Enable)
+			}
+		}
+		if got.Debug.Udp != nil {
+			if m.Debug.Udp == nil {
+				m.Debug.Udp = &sysConfigDebugUdpModel{}
+			}
+			if got.Debug.Udp.Addr != nil {
+				m.Debug.Udp.Addr = types.StringValue(*got.Debug.Udp.Addr)
+			}
+		}
+		if got.Debug.FileLog != nil {
+			if m.Debug.FileLog == nil {
+				m.Debug.FileLog = &sysConfigDebugFileLogModel{}
+			}
+			if got.Debug.FileLog.Enable != nil {
+				m.Debug.FileLog.Enable = types.BoolValue(*got.Debug.FileLog.Enable)
+			}
+		}
+	}
+	if got.RPCUdp != nil {
+		if m.RPCUdp == nil {
+			m.RPCUdp = &sysConfigRPCUdpModel{}
+		}
+		if got.RPCUdp.DstAddr != nil {
+			m.RPCUdp.DstAddr = types.StringValue(*got.RPCUdp.DstAddr)
+		}
+		if got.RPCUdp.ListenPort != nil {
+			m.RPCUdp.ListenPort = types.Float64Value(*got.RPCUdp.ListenPort)
+		}
+	}
+	if got.Sntp != nil {
+		if m.Sntp == nil {
+			m.Sntp = &sysConfigSntpModel{}
+		}
+		if got.Sntp.Server != nil {
+			m.Sntp.Server = types.StringValue(*got.Sntp.Server)
+		}
+	}
+	if got.CfgRev != nil {
+		m.CfgRev = types.Float64Value(*got.CfgRev)
+	}
+}
+
 func (r *sysConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state sysConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.SysGetConfigRequest{}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Device != nil {
-		if state.Device == nil {
-			state.Device = &sysConfigDeviceModel{}
-		}
-		if got.Device.Name != nil {
-			state.Device.Name = types.StringValue(*got.Device.Name)
-		}
-		if got.Device.EcoMode != nil {
-			state.Device.EcoMode = types.BoolValue(*got.Device.EcoMode)
-		}
-		if got.Device.MAC != nil {
-			state.Device.MAC = types.StringValue(*got.Device.MAC)
-		}
-		if got.Device.FWID != nil {
-			state.Device.FWID = types.StringValue(*got.Device.FWID)
-		}
-		if got.Device.Profile != nil {
-			state.Device.Profile = types.StringValue(*got.Device.Profile)
-		}
-		if got.Device.Discoverable != nil {
-			state.Device.Discoverable = types.BoolValue(*got.Device.Discoverable)
-		}
-		if got.Device.AddonType != nil {
-			state.Device.AddonType = types.StringValue(*got.Device.AddonType)
-		}
-		if got.Device.SysBtnToggle != nil {
-			state.Device.SysBtnToggle = types.BoolValue(*got.Device.SysBtnToggle)
-		}
-		if got.Device.TLSCheckCertValidityTime != nil {
-			state.Device.TLSCheckCertValidityTime = types.BoolValue(*got.Device.TLSCheckCertValidityTime)
-		}
-		if got.Device.EnhancedSecurity != nil {
-			state.Device.EnhancedSecurity = types.BoolValue(*got.Device.EnhancedSecurity)
-		}
-	}
-	if got.Location != nil {
-		if state.Location == nil {
-			state.Location = &sysConfigLocationModel{}
-		}
-		if got.Location.Tz != nil {
-			state.Location.Tz = types.StringValue(*got.Location.Tz)
-		}
-		if got.Location.Lat != nil {
-			state.Location.Lat = types.Float64Value(*got.Location.Lat)
-		}
-		if got.Location.Lon != nil {
-			state.Location.Lon = types.Float64Value(*got.Location.Lon)
-		}
-	}
-	if got.Debug != nil {
-		if state.Debug == nil {
-			state.Debug = &sysConfigDebugModel{}
-		}
-		if got.Debug.MQTT != nil {
-			if state.Debug.MQTT == nil {
-				state.Debug.MQTT = &sysConfigDebugMQTTModel{}
-			}
-			if got.Debug.MQTT.Enable != nil {
-				state.Debug.MQTT.Enable = types.BoolValue(*got.Debug.MQTT.Enable)
-			}
-		}
-		if got.Debug.Websocket != nil {
-			if state.Debug.Websocket == nil {
-				state.Debug.Websocket = &sysConfigDebugWebsocketModel{}
-			}
-			if got.Debug.Websocket.Enable != nil {
-				state.Debug.Websocket.Enable = types.BoolValue(*got.Debug.Websocket.Enable)
-			}
-		}
-		if got.Debug.Udp != nil {
-			if state.Debug.Udp == nil {
-				state.Debug.Udp = &sysConfigDebugUdpModel{}
-			}
-			if got.Debug.Udp.Addr != nil {
-				state.Debug.Udp.Addr = types.StringValue(*got.Debug.Udp.Addr)
-			}
-		}
-		if got.Debug.FileLog != nil {
-			if state.Debug.FileLog == nil {
-				state.Debug.FileLog = &sysConfigDebugFileLogModel{}
-			}
-			if got.Debug.FileLog.Enable != nil {
-				state.Debug.FileLog.Enable = types.BoolValue(*got.Debug.FileLog.Enable)
-			}
-		}
-	}
-	if got.RPCUdp != nil {
-		if state.RPCUdp == nil {
-			state.RPCUdp = &sysConfigRPCUdpModel{}
-		}
-		if got.RPCUdp.DstAddr != nil {
-			state.RPCUdp.DstAddr = types.StringValue(*got.RPCUdp.DstAddr)
-		}
-		if got.RPCUdp.ListenPort != nil {
-			state.RPCUdp.ListenPort = types.Float64Value(*got.RPCUdp.ListenPort)
-		}
-	}
-	if got.Sntp != nil {
-		if state.Sntp == nil {
-			state.Sntp = &sysConfigSntpModel{}
-		}
-		if got.Sntp.Server != nil {
-			state.Sntp.Server = types.StringValue(*got.Sntp.Server)
-		}
-	}
-	if got.CfgRev != nil {
-		state.CfgRev = types.Float64Value(*got.CfgRev)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *sysConfigResource) apply(plan sysConfigResourceModel, diags *diag.Diagnostics) {
+func (r *sysConfigResource) apply(ctx context.Context, plan sysConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.SysConfig
 	if plan.Device != nil {
 		cfg.Device = &components.SysConfigDevice{}
@@ -428,14 +433,6 @@ func (r *sysConfigResource) apply(plan sysConfigResourceModel, diags *diag.Diagn
 		if !plan.Device.EcoMode.IsNull() && !plan.Device.EcoMode.IsUnknown() {
 			v := plan.Device.EcoMode.ValueBool()
 			cfg.Device.EcoMode = &v
-		}
-		if !plan.Device.MAC.IsNull() && !plan.Device.MAC.IsUnknown() {
-			v := plan.Device.MAC.ValueString()
-			cfg.Device.MAC = &v
-		}
-		if !plan.Device.FWID.IsNull() && !plan.Device.FWID.IsUnknown() {
-			v := plan.Device.FWID.ValueString()
-			cfg.Device.FWID = &v
 		}
 		if !plan.Device.Profile.IsNull() && !plan.Device.Profile.IsUnknown() {
 			v := plan.Device.Profile.ValueString()
@@ -544,7 +541,11 @@ func (r *sysConfigResource) Create(ctx context.Context, req resource.CreateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -557,7 +558,11 @@ func (r *sysConfigResource) Update(ctx context.Context, req resource.UpdateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/temperature_config_resource_gen.go
+++ b/internal/provider/temperature_config_resource_gen.go
@@ -67,33 +67,40 @@ func (r *temperatureConfigResource) Schema(_ context.Context, _ resource.SchemaR
 	}
 }
 
+func (r *temperatureConfigResource) get(ctx context.Context, m *temperatureConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.TemperatureGetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Name != nil {
+		m.Name = types.StringValue(*got.Name)
+	}
+	if got.ReportThrC != nil {
+		m.ReportThrC = types.Float64Value(*got.ReportThrC)
+	}
+	if got.OffsetC != nil {
+		m.OffsetC = types.Float64Value(*got.OffsetC)
+	}
+}
+
 func (r *temperatureConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state temperatureConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.TemperatureGetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Name != nil {
-		state.Name = types.StringValue(*got.Name)
-	}
-	if got.ReportThrC != nil {
-		state.ReportThrC = types.Float64Value(*got.ReportThrC)
-	}
-	if got.OffsetC != nil {
-		state.OffsetC = types.Float64Value(*got.OffsetC)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *temperatureConfigResource) apply(plan temperatureConfigResourceModel, diags *diag.Diagnostics) {
+func (r *temperatureConfigResource) apply(ctx context.Context, plan temperatureConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.TemperatureConfig
 	cfg.ID = int(plan.ID.ValueInt64())
 	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
@@ -122,7 +129,11 @@ func (r *temperatureConfigResource) Create(ctx context.Context, req resource.Cre
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -135,7 +146,11 @@ func (r *temperatureConfigResource) Update(ctx context.Context, req resource.Upd
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/ui_config_resource_gen.go
+++ b/internal/provider/ui_config_resource_gen.go
@@ -47,27 +47,34 @@ func (r *uiConfigResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 	}
 }
 
+func (r *uiConfigResource) get(ctx context.Context, m *uiConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.UiGetConfigRequest{}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.IdleBrightness != nil {
+		m.IdleBrightness = types.Int64Value(int64(*got.IdleBrightness))
+	}
+}
+
 func (r *uiConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state uiConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.UiGetConfigRequest{}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.IdleBrightness != nil {
-		state.IdleBrightness = types.Int64Value(int64(*got.IdleBrightness))
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *uiConfigResource) apply(plan uiConfigResourceModel, diags *diag.Diagnostics) {
+func (r *uiConfigResource) apply(ctx context.Context, plan uiConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.UiConfig
 	if !plan.IdleBrightness.IsNull() && !plan.IdleBrightness.IsUnknown() {
 		v := int(plan.IdleBrightness.ValueInt64())
@@ -87,7 +94,11 @@ func (r *uiConfigResource) Create(ctx context.Context, req resource.CreateReques
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -100,7 +111,11 @@ func (r *uiConfigResource) Update(ctx context.Context, req resource.UpdateReques
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/voltmeter_config_resource_gen.go
+++ b/internal/provider/voltmeter_config_resource_gen.go
@@ -93,44 +93,51 @@ func (r *voltmeterConfigResource) Schema(_ context.Context, _ resource.SchemaReq
 	}
 }
 
+func (r *voltmeterConfigResource) get(ctx context.Context, m *voltmeterConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.VoltmeterGetConfigRequest{ID: int(m.ID.ValueInt64())}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Name != nil {
+		m.Name = types.StringValue(*got.Name)
+	}
+	if got.ReportThr != nil {
+		m.ReportThr = types.Float64Value(*got.ReportThr)
+	}
+	if got.Range != nil {
+		m.Range = types.Float64Value(*got.Range)
+	}
+	if got.Xvoltage != nil {
+		if m.Xvoltage == nil {
+			m.Xvoltage = &voltmeterConfigXvoltageModel{}
+		}
+		if got.Xvoltage.Expr != nil {
+			m.Xvoltage.Expr = types.StringValue(*got.Xvoltage.Expr)
+		}
+		if got.Xvoltage.Unit != nil {
+			m.Xvoltage.Unit = types.StringValue(*got.Xvoltage.Unit)
+		}
+	}
+}
+
 func (r *voltmeterConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state voltmeterConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.VoltmeterGetConfigRequest{ID: int(state.ID.ValueInt64())}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Name != nil {
-		state.Name = types.StringValue(*got.Name)
-	}
-	if got.ReportThr != nil {
-		state.ReportThr = types.Float64Value(*got.ReportThr)
-	}
-	if got.Range != nil {
-		state.Range = types.Float64Value(*got.Range)
-	}
-	if got.Xvoltage != nil {
-		if state.Xvoltage == nil {
-			state.Xvoltage = &voltmeterConfigXvoltageModel{}
-		}
-		if got.Xvoltage.Expr != nil {
-			state.Xvoltage.Expr = types.StringValue(*got.Xvoltage.Expr)
-		}
-		if got.Xvoltage.Unit != nil {
-			state.Xvoltage.Unit = types.StringValue(*got.Xvoltage.Unit)
-		}
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *voltmeterConfigResource) apply(plan voltmeterConfigResourceModel, diags *diag.Diagnostics) {
+func (r *voltmeterConfigResource) apply(ctx context.Context, plan voltmeterConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.VoltmeterConfig
 	cfg.ID = int(plan.ID.ValueInt64())
 	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
@@ -170,7 +177,11 @@ func (r *voltmeterConfigResource) Create(ctx context.Context, req resource.Creat
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -183,7 +194,11 @@ func (r *voltmeterConfigResource) Update(ctx context.Context, req resource.Updat
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/wifi_config_resource_gen.go
+++ b/internal/provider/wifi_config_resource_gen.go
@@ -202,92 +202,99 @@ func (r *wifiConfigResource) Schema(_ context.Context, _ resource.SchemaRequest,
 	}
 }
 
+func (r *wifiConfigResource) get(ctx context.Context, m *wifiConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.WifiGetConfigRequest{}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.AP != nil {
+		if m.AP == nil {
+			m.AP = &wifiConfigAPModel{}
+		}
+		if got.AP.SSID != nil {
+			m.AP.SSID = types.StringValue(*got.AP.SSID)
+		}
+		if got.AP.Pass != nil {
+			m.AP.Pass = types.StringValue(*got.AP.Pass)
+		}
+		if got.AP.IsOpen != nil {
+			m.AP.IsOpen = types.BoolValue(*got.AP.IsOpen)
+		}
+		if got.AP.Enable != nil {
+			m.AP.Enable = types.BoolValue(*got.AP.Enable)
+		}
+		if got.AP.RangeExtender != nil {
+			if m.AP.RangeExtender == nil {
+				m.AP.RangeExtender = &wifiConfigAPRangeExtenderModel{}
+			}
+			if got.AP.RangeExtender.Enable != nil {
+				m.AP.RangeExtender.Enable = types.BoolValue(*got.AP.RangeExtender.Enable)
+			}
+		}
+	}
+	if got.Sta != nil {
+		if m.Sta == nil {
+			m.Sta = &wifiConfigStaModel{}
+		}
+		if got.Sta.SSID != nil {
+			m.Sta.SSID = types.StringValue(*got.Sta.SSID)
+		}
+		if got.Sta.Pass != nil {
+			m.Sta.Pass = types.StringValue(*got.Sta.Pass)
+		}
+		if got.Sta.IsOpen != nil {
+			m.Sta.IsOpen = types.BoolValue(*got.Sta.IsOpen)
+		}
+		if got.Sta.Enable != nil {
+			m.Sta.Enable = types.BoolValue(*got.Sta.Enable)
+		}
+		if got.Sta.Ipv4mode != nil {
+			m.Sta.Ipv4mode = types.StringValue(*got.Sta.Ipv4mode)
+		}
+		if got.Sta.IP != nil {
+			m.Sta.IP = types.StringValue(*got.Sta.IP)
+		}
+		if got.Sta.Netmask != nil {
+			m.Sta.Netmask = types.StringValue(*got.Sta.Netmask)
+		}
+		if got.Sta.Gw != nil {
+			m.Sta.Gw = types.StringValue(*got.Sta.Gw)
+		}
+		if got.Sta.Nameserver != nil {
+			m.Sta.Nameserver = types.StringValue(*got.Sta.Nameserver)
+		}
+	}
+	if got.Roam != nil {
+		if m.Roam == nil {
+			m.Roam = &wifiConfigRoamModel{}
+		}
+		if got.Roam.RssiThr != nil {
+			m.Roam.RssiThr = types.Float64Value(*got.Roam.RssiThr)
+		}
+		if got.Roam.Interval != nil {
+			m.Roam.Interval = types.Float64Value(*got.Roam.Interval)
+		}
+	}
+}
+
 func (r *wifiConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state wifiConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.WifiGetConfigRequest{}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.AP != nil {
-		if state.AP == nil {
-			state.AP = &wifiConfigAPModel{}
-		}
-		if got.AP.SSID != nil {
-			state.AP.SSID = types.StringValue(*got.AP.SSID)
-		}
-		if got.AP.Pass != nil {
-			state.AP.Pass = types.StringValue(*got.AP.Pass)
-		}
-		if got.AP.IsOpen != nil {
-			state.AP.IsOpen = types.BoolValue(*got.AP.IsOpen)
-		}
-		if got.AP.Enable != nil {
-			state.AP.Enable = types.BoolValue(*got.AP.Enable)
-		}
-		if got.AP.RangeExtender != nil {
-			if state.AP.RangeExtender == nil {
-				state.AP.RangeExtender = &wifiConfigAPRangeExtenderModel{}
-			}
-			if got.AP.RangeExtender.Enable != nil {
-				state.AP.RangeExtender.Enable = types.BoolValue(*got.AP.RangeExtender.Enable)
-			}
-		}
-	}
-	if got.Sta != nil {
-		if state.Sta == nil {
-			state.Sta = &wifiConfigStaModel{}
-		}
-		if got.Sta.SSID != nil {
-			state.Sta.SSID = types.StringValue(*got.Sta.SSID)
-		}
-		if got.Sta.Pass != nil {
-			state.Sta.Pass = types.StringValue(*got.Sta.Pass)
-		}
-		if got.Sta.IsOpen != nil {
-			state.Sta.IsOpen = types.BoolValue(*got.Sta.IsOpen)
-		}
-		if got.Sta.Enable != nil {
-			state.Sta.Enable = types.BoolValue(*got.Sta.Enable)
-		}
-		if got.Sta.Ipv4mode != nil {
-			state.Sta.Ipv4mode = types.StringValue(*got.Sta.Ipv4mode)
-		}
-		if got.Sta.IP != nil {
-			state.Sta.IP = types.StringValue(*got.Sta.IP)
-		}
-		if got.Sta.Netmask != nil {
-			state.Sta.Netmask = types.StringValue(*got.Sta.Netmask)
-		}
-		if got.Sta.Gw != nil {
-			state.Sta.Gw = types.StringValue(*got.Sta.Gw)
-		}
-		if got.Sta.Nameserver != nil {
-			state.Sta.Nameserver = types.StringValue(*got.Sta.Nameserver)
-		}
-	}
-	if got.Roam != nil {
-		if state.Roam == nil {
-			state.Roam = &wifiConfigRoamModel{}
-		}
-		if got.Roam.RssiThr != nil {
-			state.Roam.RssiThr = types.Float64Value(*got.Roam.RssiThr)
-		}
-		if got.Roam.Interval != nil {
-			state.Roam.Interval = types.Float64Value(*got.Roam.Interval)
-		}
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *wifiConfigResource) apply(plan wifiConfigResourceModel, diags *diag.Diagnostics) {
+func (r *wifiConfigResource) apply(ctx context.Context, plan wifiConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.WifiConfig
 	if plan.AP != nil {
 		cfg.AP = &components.WifiConfigAP{}
@@ -379,7 +386,11 @@ func (r *wifiConfigResource) Create(ctx context.Context, req resource.CreateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -392,7 +403,11 @@ func (r *wifiConfigResource) Update(ctx context.Context, req resource.UpdateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/ws_config_resource_gen.go
+++ b/internal/provider/ws_config_resource_gen.go
@@ -55,30 +55,37 @@ func (r *wsConfigResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 	}
 }
 
+func (r *wsConfigResource) get(ctx context.Context, m *wsConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.WsGetConfigRequest{}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Enable != nil {
+		m.Enable = types.BoolValue(*got.Enable)
+	}
+	if got.Server != nil {
+		m.Server = types.StringValue(*got.Server)
+	}
+}
+
 func (r *wsConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state wsConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.WsGetConfigRequest{}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Enable != nil {
-		state.Enable = types.BoolValue(*got.Enable)
-	}
-	if got.Server != nil {
-		state.Server = types.StringValue(*got.Server)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *wsConfigResource) apply(plan wsConfigResourceModel, diags *diag.Diagnostics) {
+func (r *wsConfigResource) apply(ctx context.Context, plan wsConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.WsConfig
 	if !plan.Enable.IsNull() && !plan.Enable.IsUnknown() {
 		v := plan.Enable.ValueBool()
@@ -102,7 +109,11 @@ func (r *wsConfigResource) Create(ctx context.Context, req resource.CreateReques
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -115,7 +126,11 @@ func (r *wsConfigResource) Update(ctx context.Context, req resource.UpdateReques
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/zigbee_config_resource_gen.go
+++ b/internal/provider/zigbee_config_resource_gen.go
@@ -47,27 +47,34 @@ func (r *zigbeeConfigResource) Schema(_ context.Context, _ resource.SchemaReques
 	}
 }
 
+func (r *zigbeeConfigResource) get(ctx context.Context, m *zigbeeConfigResourceModel, diags *diag.Diagnostics) {
+	client := resty.New()
+	defer client.Close()
+	client.SetBaseURL("http://" + m.IP.ValueString())
+	got, _, err := (&components.ZigbeeGetConfigRequest{}).Do(client)
+	if err != nil {
+		diags.AddError("Failed to read config", err.Error())
+		return
+	}
+	if got.Enable != nil {
+		m.Enable = types.BoolValue(*got.Enable)
+	}
+}
+
 func (r *zigbeeConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state zigbeeConfigResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := resty.New()
-	defer client.Close()
-	client.SetBaseURL("http://" + state.IP.ValueString())
-	got, _, err := (&components.ZigbeeGetConfigRequest{}).Do(client)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read config", err.Error())
+	r.get(ctx, &state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
-	}
-	if got.Enable != nil {
-		state.Enable = types.BoolValue(*got.Enable)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func (r *zigbeeConfigResource) apply(plan zigbeeConfigResourceModel, diags *diag.Diagnostics) {
+func (r *zigbeeConfigResource) apply(ctx context.Context, plan zigbeeConfigResourceModel, diags *diag.Diagnostics) {
 	var cfg components.ZigbeeConfig
 	if !plan.Enable.IsNull() && !plan.Enable.IsUnknown() {
 		v := plan.Enable.ValueBool()
@@ -87,7 +94,11 @@ func (r *zigbeeConfigResource) Create(ctx context.Context, req resource.CreateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -100,7 +111,11 @@ func (r *zigbeeConfigResource) Update(ctx context.Context, req resource.UpdateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.apply(plan, &resp.Diagnostics)
+	r.apply(ctx, plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.get(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}


### PR DESCRIPTION
Extends the provider config generator (`internal/provider/gen/main.go`) with two capabilities discussed after v0.3.0.

## 1. Scalar arrays → `schema.ListAttribute`

Config fields whose element type is `number`/`integer`/`string`/`boolean` are now representable. The model field becomes `types.List`, reads use `types.ListValueFrom`, writes use `ElementsAs`. Arrays-of-arrays and untyped/object arrays are still skipped (no fidelity loss vs. before).

10 resources gain list attributes (`em`, `em1`, `pm1`, `dali`, `devicepower`, `emdata`, `em1data`, `rgb`, `rgbw`, `rgbcct`) — e.g. `EM1.alarms` voltage/current/power thresholds.

## 2. Read-only fields → `Computed`-only

Fields documented `Read-only ...` are now emitted `Computed`-only: dropped from the apply path (no validators, never written to the device) and surfaced as `Computed` in the schema. Because `Computed` fields are unknown-after-apply, `Create`/`Update` now read the config back from the device after applying (shared `get()` helper) and set that as the final state. `sys.mac` and `sys.fw_id` are the first such fields.

## Verification

- `go build`/`go vet`/`go test` pass
- generation is idempotent (regenerated twice, no diff)
- `tfplugindocs` regenerated (13 doc files updated)
- `terraform validate` **and** `terraform plan` against the live fleet report **no drift**

🤖 Generated with [Claude Code](https://claude.com/claude-code)