### PR TITLE
provider: regenerate from shelly-go parser fix (value-table fields)

### DIFF
--- a/docs/resources/cover_config.md
+++ b/docs/resources/cover_config.md
@@ -24,7 +24,10 @@ description: |-
 
 - `current_limit` (Number) Amperes, a limit that must be exceeded to trigger an overcurrent error
 - `in_locked` (Boolean) If True, all changes to physical inputs are ignored, regardless of mode.
+- `in_mode` (String) One of single, dual or detached, only present if there is at least one input associated with the Cover instance: single, dual, detached.
 - `initial_state` (String) Defines Cover target state on power-on, one of open (Cover will fully open), closed (Cover will fully close) or stopped (Cover will not change its position)
+- `invert_directions` (Boolean) Defines the motor rotation for open and close directions (changing this parameter requires a reboot): false, true.
+- `maintenance_mode` (Boolean) Can be used to temporarily freeze all motions for maintenance: false, true.
 - `maxtime_close` (Number) Default timeout after which Cover will stop moving in a close direction
 - `maxtime_open` (Number) Default timeout after which Cover will stop moving in open direction
 - `motor` (Attributes) (see [below for nested schema](#nestedatt--motor))
@@ -33,6 +36,7 @@ description: |-
 - `power_limit` (Number) Watts, a limit that must be exceeded to trigger an overpower error
 - `safety_switch` (Attributes) (see [below for nested schema](#nestedatt--safety_switch))
 - `slat` (Attributes) (see [below for nested schema](#nestedatt--slat))
+- `swap_inputs` (Boolean) Defines whether the functions of the two inputs are swapped. Only present if there are two inputs associated with the Cover instance. Documented without a type by Shelly.
 - `undervoltage_limit` (Number) Volts, a limit that must be subceeded to trigger an undervoltage error
 - `voltage_limit` (Number) Volts, a limit that must be exceeded to trigger an overvoltage error
 
@@ -50,6 +54,7 @@ Optional:
 
 Optional:
 
+- `action` (String) The recovery action that should be performed if the safety switch is engaged while moving in a monitored direction, one of the: stop, reverse.
 - `direction` (String) The direction of motion for which the safety switch should be monitored, one of open, close, both
 - `enable` (Boolean) true when obstruction detection is enabled, false otherwise
 - `holdoff` (Number) Seconds, time to wait after Cover starts moving before obstruction detection is activated (to avoid false detections because of the initial power consumption spike)
@@ -61,6 +66,8 @@ Optional:
 
 Optional:
 
+- `action` (String) The recovery action which should be performed if the safety switch is engaged while moving in a monitored direction, is one of the: stop, reverse, pause.
+- `allowed_move` (String) Allowed movement direction when the safety switch is engaged while moving in a monitored direction: null, reverse.
 - `direction` (String) The direction of motion for which the safety switch should be monitored, one of open, close, both
 - `enable` (Boolean) true when the safety switch is enabled, false otherwise
 

--- a/docs/resources/mqtt_config.md
+++ b/docs/resources/mqtt_config.md
@@ -21,10 +21,13 @@ description: |-
 
 ### Optional
 
+- `client_id` (String) Identifies each MQTT client that connects to an MQTT brokers
 - `enable` (Boolean) True if MQTT connection is enabled, false otherwise
 - `enable_control` (Boolean) Enable the MQTT control feature. Defalut value: true
 - `rpc_ntf` (Boolean) Enables RPC notifications (NotifyStatus and NotifyEvent) to be published on <device_id|topic_prefix>/events/rpc (<topic_prefix> when a custom prefix is set, <device_id> otherwise). Default value: true.
 - `server` (String) Host name of the MQTT server. Can be followed by port number - host:port
+- `ssl_ca` (String) Type of the TCP sockets
 - `status_ntf` (Boolean) Enables publishing the complete component status on <device_id|topic_prefix>/status/<component>:<id> (<topic_prefix> when a custom prefix is set, <device_id> otherwise). The complete status will be published if a signifficant change occurred. Default value: false
+- `topic_prefix` (String) Prefix of the topics on which device publish/subscribe. Limited to 300 characters. Could not start with $ and #, +, %, ? are not allowed.
 - `use_client_cert` (Boolean) Enable or diable usage of client certifactes to use MQTT with encription, default: false
 - `user` (String) Username

--- a/docs/resources/ws_config.md
+++ b/docs/resources/ws_config.md
@@ -23,3 +23,4 @@ description: |-
 
 - `enable` (Boolean) true if websocket outbound connection is enabled, false otherwise
 - `server` (String) Name of the server to which the device is connected. When prefixed with wss:// a TLS socket will be used
+- `ssl_ca` (String) Type of the TCP sockets

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.4
 
 require (
-	github.com/DonRobo/shelly-go v0.0.0-20260622131612-6822d11abec6
+	github.com/DonRobo/shelly-go v0.2.1-0.20260623091310-69fd4550c4c7
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/DonRobo/shelly-go v0.0.0-20260622131612-6822d11abec6 h1:awUjD2pUMrimjRCtWRxFfnv5Y1BiS93yX1bTg/SxlXE=
-github.com/DonRobo/shelly-go v0.0.0-20260622131612-6822d11abec6/go.mod h1:RN1sX+/X8foe8AVeOEt0TWujIoREl0vhsHnOQSQqCp8=
+github.com/DonRobo/shelly-go v0.2.1-0.20260623091310-69fd4550c4c7 h1:HvRqdv9Rvpyr5R2Z9pd3GE43g6VeLSTYmzdAQMScy/8=
+github.com/DonRobo/shelly-go v0.2.1-0.20260623091310-69fd4550c4c7/go.mod h1:RN1sX+/X8foe8AVeOEt0TWujIoREl0vhsHnOQSQqCp8=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/internal/provider/cover_config_resource_gen.go
+++ b/internal/provider/cover_config_resource_gen.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/DonRobo/shelly-go/components"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -15,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"resty.dev/v3"
 	"strconv"
@@ -38,13 +40,16 @@ type coverConfigMotorModel struct {
 type coverConfigObstructionDetectionModel struct {
 	Enable    types.Bool    `tfsdk:"enable"`
 	Direction types.String  `tfsdk:"direction"`
+	Action    types.String  `tfsdk:"action"`
 	PowerThr  types.Float64 `tfsdk:"power_thr"`
 	Holdoff   types.Float64 `tfsdk:"holdoff"`
 }
 
 type coverConfigSafetySwitchModel struct {
-	Enable    types.Bool   `tfsdk:"enable"`
-	Direction types.String `tfsdk:"direction"`
+	Enable      types.Bool   `tfsdk:"enable"`
+	Direction   types.String `tfsdk:"direction"`
+	Action      types.String `tfsdk:"action"`
+	AllowedMove types.String `tfsdk:"allowed_move"`
 }
 
 type coverConfigSlatModel struct {
@@ -60,6 +65,7 @@ type coverConfigResourceModel struct {
 	IP                   types.String                          `tfsdk:"ip"`
 	ID                   types.Int64                           `tfsdk:"id"`
 	Name                 types.String                          `tfsdk:"name"`
+	InMode               types.String                          `tfsdk:"in_mode"`
 	InLocked             types.Bool                            `tfsdk:"in_locked"`
 	InitialState         types.String                          `tfsdk:"initial_state"`
 	PowerLimit           types.Float64                         `tfsdk:"power_limit"`
@@ -69,9 +75,12 @@ type coverConfigResourceModel struct {
 	Motor                *coverConfigMotorModel                `tfsdk:"motor"`
 	MaxtimeOpen          types.Float64                         `tfsdk:"maxtime_open"`
 	MaxtimeClose         types.Float64                         `tfsdk:"maxtime_close"`
+	InvertDirections     types.Bool                            `tfsdk:"invert_directions"`
+	MaintenanceMode      types.Bool                            `tfsdk:"maintenance_mode"`
 	ObstructionDetection *coverConfigObstructionDetectionModel `tfsdk:"obstruction_detection"`
 	SafetySwitch         *coverConfigSafetySwitchModel         `tfsdk:"safety_switch"`
 	Slat                 *coverConfigSlatModel                 `tfsdk:"slat"`
+	SwapInputs           types.Bool                            `tfsdk:"swap_inputs"`
 }
 
 func (r *coverConfigResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -87,6 +96,13 @@ func (r *coverConfigResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Optional:            true,
 				Computed:            true,
 				MarkdownDescription: "Name of the Cover component instance",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"in_mode": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "One of single, dual or detached, only present if there is at least one input associated with the Cover instance: single, dual, detached.",
+				Validators:          []validator.String{stringvalidator.OneOf("single", "dual", "detached")},
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"in_locked": schema.BoolAttribute{
@@ -156,6 +172,18 @@ func (r *coverConfigResource) Schema(_ context.Context, _ resource.SchemaRequest
 				MarkdownDescription: "Default timeout after which Cover will stop moving in a close direction",
 				PlanModifiers:       []planmodifier.Float64{float64planmodifier.UseStateForUnknown()},
 			},
+			"invert_directions": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Defines the motor rotation for open and close directions (changing this parameter requires a reboot): false, true.",
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+			},
+			"maintenance_mode": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Can be used to temporarily freeze all motions for maintenance: false, true.",
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+			},
 			"obstruction_detection": schema.SingleNestedAttribute{
 				Optional:      true,
 				Computed:      true,
@@ -171,6 +199,13 @@ func (r *coverConfigResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:            true,
 						Computed:            true,
 						MarkdownDescription: "The direction of motion for which the safety switch should be monitored, one of open, close, both",
+						PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+					},
+					"action": schema.StringAttribute{
+						Optional:            true,
+						Computed:            true,
+						MarkdownDescription: "The recovery action that should be performed if the safety switch is engaged while moving in a monitored direction, one of the: stop, reverse.",
+						Validators:          []validator.String{stringvalidator.OneOf("stop", "reverse")},
 						PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 					},
 					"power_thr": schema.Float64Attribute{
@@ -202,6 +237,20 @@ func (r *coverConfigResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:            true,
 						Computed:            true,
 						MarkdownDescription: "The direction of motion for which the safety switch should be monitored, one of open, close, both",
+						PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+					},
+					"action": schema.StringAttribute{
+						Optional:            true,
+						Computed:            true,
+						MarkdownDescription: "The recovery action which should be performed if the safety switch is engaged while moving in a monitored direction, is one of the: stop, reverse, pause.",
+						Validators:          []validator.String{stringvalidator.OneOf("stop", "reverse", "pause")},
+						PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+					},
+					"allowed_move": schema.StringAttribute{
+						Optional:            true,
+						Computed:            true,
+						MarkdownDescription: "Allowed movement direction when the safety switch is engaged while moving in a monitored direction: null, reverse.",
+						Validators:          []validator.String{stringvalidator.OneOf("reverse")},
 						PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 					},
 				},
@@ -249,6 +298,12 @@ func (r *coverConfigResource) Schema(_ context.Context, _ resource.SchemaRequest
 					},
 				},
 			},
+			"swap_inputs": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Defines whether the functions of the two inputs are swapped. Only present if there are two inputs associated with the Cover instance. Documented without a type by Shelly.",
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+			},
 		},
 	}
 }
@@ -264,6 +319,9 @@ func (r *coverConfigResource) get(ctx context.Context, m *coverConfigResourceMod
 	}
 	if got.Name != nil {
 		m.Name = types.StringValue(*got.Name)
+	}
+	if got.InMode != nil {
+		m.InMode = types.StringValue(*got.InMode)
 	}
 	if got.InLocked != nil {
 		m.InLocked = types.BoolValue(*got.InLocked)
@@ -300,6 +358,12 @@ func (r *coverConfigResource) get(ctx context.Context, m *coverConfigResourceMod
 	if got.MaxtimeClose != nil {
 		m.MaxtimeClose = types.Float64Value(*got.MaxtimeClose)
 	}
+	if got.InvertDirections != nil {
+		m.InvertDirections = types.BoolValue(*got.InvertDirections)
+	}
+	if got.MaintenanceMode != nil {
+		m.MaintenanceMode = types.BoolValue(*got.MaintenanceMode)
+	}
 	if got.ObstructionDetection != nil {
 		if m.ObstructionDetection == nil {
 			m.ObstructionDetection = &coverConfigObstructionDetectionModel{}
@@ -309,6 +373,9 @@ func (r *coverConfigResource) get(ctx context.Context, m *coverConfigResourceMod
 		}
 		if got.ObstructionDetection.Direction != nil {
 			m.ObstructionDetection.Direction = types.StringValue(*got.ObstructionDetection.Direction)
+		}
+		if got.ObstructionDetection.Action != nil {
+			m.ObstructionDetection.Action = types.StringValue(*got.ObstructionDetection.Action)
 		}
 		if got.ObstructionDetection.PowerThr != nil {
 			m.ObstructionDetection.PowerThr = types.Float64Value(*got.ObstructionDetection.PowerThr)
@@ -326,6 +393,12 @@ func (r *coverConfigResource) get(ctx context.Context, m *coverConfigResourceMod
 		}
 		if got.SafetySwitch.Direction != nil {
 			m.SafetySwitch.Direction = types.StringValue(*got.SafetySwitch.Direction)
+		}
+		if got.SafetySwitch.Action != nil {
+			m.SafetySwitch.Action = types.StringValue(*got.SafetySwitch.Action)
+		}
+		if got.SafetySwitch.AllowedMove != nil {
+			m.SafetySwitch.AllowedMove = types.StringValue(*got.SafetySwitch.AllowedMove)
 		}
 	}
 	if got.Slat != nil {
@@ -351,6 +424,9 @@ func (r *coverConfigResource) get(ctx context.Context, m *coverConfigResourceMod
 			m.Slat.PreciseCtl = types.BoolValue(*got.Slat.PreciseCtl)
 		}
 	}
+	if got.SwapInputs != nil {
+		m.SwapInputs = types.BoolValue(*got.SwapInputs)
+	}
 }
 
 func (r *coverConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -372,6 +448,10 @@ func (r *coverConfigResource) apply(ctx context.Context, plan coverConfigResourc
 	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
 		v := plan.Name.ValueString()
 		cfg.Name = &v
+	}
+	if !plan.InMode.IsNull() && !plan.InMode.IsUnknown() {
+		v := plan.InMode.ValueString()
+		cfg.InMode = &v
 	}
 	if !plan.InLocked.IsNull() && !plan.InLocked.IsUnknown() {
 		v := plan.InLocked.ValueBool()
@@ -416,6 +496,14 @@ func (r *coverConfigResource) apply(ctx context.Context, plan coverConfigResourc
 		v := plan.MaxtimeClose.ValueFloat64()
 		cfg.MaxtimeClose = &v
 	}
+	if !plan.InvertDirections.IsNull() && !plan.InvertDirections.IsUnknown() {
+		v := plan.InvertDirections.ValueBool()
+		cfg.InvertDirections = &v
+	}
+	if !plan.MaintenanceMode.IsNull() && !plan.MaintenanceMode.IsUnknown() {
+		v := plan.MaintenanceMode.ValueBool()
+		cfg.MaintenanceMode = &v
+	}
 	if plan.ObstructionDetection != nil {
 		cfg.ObstructionDetection = &components.CoverConfigObstructionDetection{}
 		if !plan.ObstructionDetection.Enable.IsNull() && !plan.ObstructionDetection.Enable.IsUnknown() {
@@ -425,6 +513,10 @@ func (r *coverConfigResource) apply(ctx context.Context, plan coverConfigResourc
 		if !plan.ObstructionDetection.Direction.IsNull() && !plan.ObstructionDetection.Direction.IsUnknown() {
 			v := plan.ObstructionDetection.Direction.ValueString()
 			cfg.ObstructionDetection.Direction = &v
+		}
+		if !plan.ObstructionDetection.Action.IsNull() && !plan.ObstructionDetection.Action.IsUnknown() {
+			v := plan.ObstructionDetection.Action.ValueString()
+			cfg.ObstructionDetection.Action = &v
 		}
 		if !plan.ObstructionDetection.PowerThr.IsNull() && !plan.ObstructionDetection.PowerThr.IsUnknown() {
 			v := plan.ObstructionDetection.PowerThr.ValueFloat64()
@@ -444,6 +536,14 @@ func (r *coverConfigResource) apply(ctx context.Context, plan coverConfigResourc
 		if !plan.SafetySwitch.Direction.IsNull() && !plan.SafetySwitch.Direction.IsUnknown() {
 			v := plan.SafetySwitch.Direction.ValueString()
 			cfg.SafetySwitch.Direction = &v
+		}
+		if !plan.SafetySwitch.Action.IsNull() && !plan.SafetySwitch.Action.IsUnknown() {
+			v := plan.SafetySwitch.Action.ValueString()
+			cfg.SafetySwitch.Action = &v
+		}
+		if !plan.SafetySwitch.AllowedMove.IsNull() && !plan.SafetySwitch.AllowedMove.IsUnknown() {
+			v := plan.SafetySwitch.AllowedMove.ValueString()
+			cfg.SafetySwitch.AllowedMove = &v
 		}
 	}
 	if plan.Slat != nil {
@@ -472,6 +572,10 @@ func (r *coverConfigResource) apply(ctx context.Context, plan coverConfigResourc
 			v := plan.Slat.PreciseCtl.ValueBool()
 			cfg.Slat.PreciseCtl = &v
 		}
+	}
+	if !plan.SwapInputs.IsNull() && !plan.SwapInputs.IsUnknown() {
+		v := plan.SwapInputs.ValueBool()
+		cfg.SwapInputs = &v
 	}
 	client := resty.New()
 	defer client.Close()

--- a/internal/provider/mqtt_config_resource_gen.go
+++ b/internal/provider/mqtt_config_resource_gen.go
@@ -5,6 +5,7 @@ package provider
 import (
 	"context"
 	"github.com/DonRobo/shelly-go/components"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -12,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"resty.dev/v3"
 )
@@ -29,7 +31,10 @@ type mqttConfigResourceModel struct {
 	IP            types.String `tfsdk:"ip"`
 	Enable        types.Bool   `tfsdk:"enable"`
 	Server        types.String `tfsdk:"server"`
+	ClientID      types.String `tfsdk:"client_id"`
 	User          types.String `tfsdk:"user"`
+	SSLCA         types.String `tfsdk:"ssl_ca"`
+	TopicPrefix   types.String `tfsdk:"topic_prefix"`
 	RPCNtf        types.Bool   `tfsdk:"rpc_ntf"`
 	StatusNtf     types.Bool   `tfsdk:"status_ntf"`
 	UseClientCert types.Bool   `tfsdk:"use_client_cert"`
@@ -56,10 +61,29 @@ func (r *mqttConfigResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				MarkdownDescription: "Host name of the MQTT server. Can be followed by port number - host:port",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
+			"client_id": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Identifies each MQTT client that connects to an MQTT brokers",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
 			"user": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				MarkdownDescription: "Username",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"ssl_ca": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Type of the TCP sockets",
+				Validators:          []validator.String{stringvalidator.OneOf("*", "user_ca.pem", "ca.pem")},
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"topic_prefix": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Prefix of the topics on which device publish/subscribe. Limited to 300 characters. Could not start with $ and #, +, %, ? are not allowed.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"rpc_ntf": schema.BoolAttribute{
@@ -105,8 +129,17 @@ func (r *mqttConfigResource) get(ctx context.Context, m *mqttConfigResourceModel
 	if got.Server != nil {
 		m.Server = types.StringValue(*got.Server)
 	}
+	if got.ClientID != nil {
+		m.ClientID = types.StringValue(*got.ClientID)
+	}
 	if got.User != nil {
 		m.User = types.StringValue(*got.User)
+	}
+	if got.SSLCA != nil {
+		m.SSLCA = types.StringValue(*got.SSLCA)
+	}
+	if got.TopicPrefix != nil {
+		m.TopicPrefix = types.StringValue(*got.TopicPrefix)
 	}
 	if got.RPCNtf != nil {
 		m.RPCNtf = types.BoolValue(*got.RPCNtf)
@@ -145,9 +178,21 @@ func (r *mqttConfigResource) apply(ctx context.Context, plan mqttConfigResourceM
 		v := plan.Server.ValueString()
 		cfg.Server = &v
 	}
+	if !plan.ClientID.IsNull() && !plan.ClientID.IsUnknown() {
+		v := plan.ClientID.ValueString()
+		cfg.ClientID = &v
+	}
 	if !plan.User.IsNull() && !plan.User.IsUnknown() {
 		v := plan.User.ValueString()
 		cfg.User = &v
+	}
+	if !plan.SSLCA.IsNull() && !plan.SSLCA.IsUnknown() {
+		v := plan.SSLCA.ValueString()
+		cfg.SSLCA = &v
+	}
+	if !plan.TopicPrefix.IsNull() && !plan.TopicPrefix.IsUnknown() {
+		v := plan.TopicPrefix.ValueString()
+		cfg.TopicPrefix = &v
 	}
 	if !plan.RPCNtf.IsNull() && !plan.RPCNtf.IsUnknown() {
 		v := plan.RPCNtf.ValueBool()

--- a/internal/provider/ws_config_resource_gen.go
+++ b/internal/provider/ws_config_resource_gen.go
@@ -5,6 +5,7 @@ package provider
 import (
 	"context"
 	"github.com/DonRobo/shelly-go/components"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -12,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"resty.dev/v3"
 )
@@ -29,6 +31,7 @@ type wsConfigResourceModel struct {
 	IP     types.String `tfsdk:"ip"`
 	Enable types.Bool   `tfsdk:"enable"`
 	Server types.String `tfsdk:"server"`
+	SSLCA  types.String `tfsdk:"ssl_ca"`
 }
 
 func (r *wsConfigResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -51,6 +54,13 @@ func (r *wsConfigResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				MarkdownDescription: "Name of the server to which the device is connected. When prefixed with wss:// a TLS socket will be used",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
+			"ssl_ca": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Type of the TCP sockets",
+				Validators:          []validator.String{stringvalidator.OneOf("*", "user_ca.pem", "ca.pem")},
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
 		},
 	}
 }
@@ -69,6 +79,9 @@ func (r *wsConfigResource) get(ctx context.Context, m *wsConfigResourceModel, di
 	}
 	if got.Server != nil {
 		m.Server = types.StringValue(*got.Server)
+	}
+	if got.SSLCA != nil {
+		m.SSLCA = types.StringValue(*got.SSLCA)
 	}
 }
 
@@ -94,6 +107,10 @@ func (r *wsConfigResource) apply(ctx context.Context, plan wsConfigResourceModel
 	if !plan.Server.IsNull() && !plan.Server.IsUnknown() {
 		v := plan.Server.ValueString()
 		cfg.Server = &v
+	}
+	if !plan.SSLCA.IsNull() && !plan.SSLCA.IsUnknown() {
+		v := plan.SSLCA.ValueString()
+		cfg.SSLCA = &v
 	}
 	client := resty.New()
 	defer client.Close()


### PR DESCRIPTION
## What

Re-pins `shelly-go` to the merged parser fix ([shelly-go#13](https://github.com/DonRobo/shelly-go/pull/13) — *don't treat value-enumeration tables as object sub-property tables*) and regenerates. **Pure codegen refresh — no generator changes.**

## New schema attributes

All `Optional + Computed`, like every generated attribute, so they're safe to leave unset (populated from the device on read-back) or pin selectively:

| Resource | New attributes |
|---|---|
| `cover_config` | `in_mode`, `swap_inputs`, `invert_directions`, `maintenance_mode`, `obstruction_detection.action`, `safety_switch.action`, `safety_switch.allowed_move` |
| `mqtt_config` | `client_id`, `ssl_ca`, `topic_prefix` |
| `ws_config` | `ssl_ca` |

These were all documented by Shelly but silently dropped by the old parser. `swap_inputs` additionally needed a library-side exception (its docs Type cell is blank).

## Verification

- `go mod tidy` clean, `go generate ./...` reproduces this diff.
- `go build ./...`, `go vet ./...`, `go test ./...` pass.
- Confirmed the four new `cover_config` attributes are wired into the schema, the model struct, and the `get()` read-back.

After merge: tag a new release so the infra repo can pin it and expose the cover behavior fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)