### PR TITLE
ci: only run tests on push to main (dedupe PR runs)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,10 @@ on:
     paths-ignore:
       - 'README.md'
   push:
+    # Only run on pushes to main; branch pushes are already covered by the
+    # pull_request trigger, so scoping this avoids duplicate runs per PR.
+    branches:
+      - main
     paths-ignore:
       - 'README.md'
 


### PR DESCRIPTION
The `Tests` workflow (`test.yml`) triggers on **both** `push` and `pull_request`. For a PR from a same-repo branch, both events fire on each push, so CI runs the whole suite **twice** per update.

Scope the `push` trigger to `main` only — branch pushes are already covered by the `pull_request` trigger. Result:
- feature-branch push → one run (via `pull_request`)
- merge to `main` → one run (via `push`)

This is the scaffolding-template default behavior, not a repo-specific issue; `template_sync` may re-introduce it on the next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)